### PR TITLE
[FIX] 실시간 대전 매칭에서 ROUND 0으로 표시되는 버그 수정

### DIFF
--- a/packages/frontend/src/pages/match/Match.tsx
+++ b/packages/frontend/src/pages/match/Match.tsx
@@ -25,13 +25,11 @@ export default function Match() {
         />
       </div>
 
-      {matchState === 'matching' && <Matching />}
-      {matchState === 'inGame' && (
-        <RoundProvider>
-          <InGame />
-        </RoundProvider>
-      )}
-      {matchState === 'match-end' && <MatchResult />}
+      <RoundProvider>
+        {matchState === 'matching' && <Matching />}
+        {matchState === 'inGame' && <InGame />}
+        {matchState === 'match-end' && <MatchResult />}
+      </RoundProvider>
     </div>
   );
 }


### PR DESCRIPTION
## 📝 개요 (Description)

실시간 대전 매칭에서 첫 번째 라운드에 "ROUND 0"으로 표시되는 버그를 수정합니다.

`RoundProvider`가 `matchState === 'inGame'`일 때만 마운트되어, 서버에서 `match:found` 직후 발송하는 `round:ready` 이벤트가 리스너 등록 전에 도착하여 유실되는 문제가 있었습니다.

`RoundProvider`를 매칭 화면부터 미리 마운트하여 이벤트 리스너를 사전에 등록하도록 수정했습니다.

## 🔗 관련 이슈 (Related Issues)

- Closes #184

## 🏷️ 작업 유형 (Type of Change)

- [ ] ✨ 기능 추가 (New Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] 🔧 설정 변경 및 기타 (Config & Other)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 컴파일/빌드 되나요?
- [x] 기존 테스트를 통과했나요? (새로운 테스트가 필요하다면 추가했나요?)
- [x] 스스로 코드를 리뷰했나요? (Self-review)
- [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
- [ ] 문서(README 등)에 변경 사항을 업데이트했나요?

## 📸 스크린샷 (Screenshots)

### Before (Performance 쓰로틀링 시 ROUND 0 표시)

<img width="2560" height="1440" alt="Screenshot 2026-01-28 at 16 54 49" src="https://github.com/user-attachments/assets/b28b6938-cb4c-401c-9053-16c12089f920" />


### After (수정 후 ROUND 1 정상 표시)

<img width="2560" height="1440" alt="Screenshot 2026-01-28 at 17 16 46" src="https://github.com/user-attachments/assets/6eab1952-e459-4e30-a73a-9633adbf5697" />

## 🎸 기타 (Etc)

- 네트워크 지연이 있는 환경(Performance 탭 쓰로틀링)에서 재현 가능했던 버그입니다.
- `round:ready` 이벤트가 `RoundProvider` 마운트 전에 도착하면 유실되어 `roundIndex`가 초기값 0으로 유지되는 것이 원인이었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이 버전에는 **사용자에게 직접 영향을 미치는 변경 사항이 없습니다**. 

* **개선**
  * 내부 렌더링 구조 최적화를 통한 코드 유지보수성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->