### PR TITLE
[Fix] 객관식은 버튼, 단답형 및 서술형은 enter키로 답안을 제출하도록 수정

### DIFF
--- a/packages/frontend/src/pages/match/components/in-game/Playing.tsx
+++ b/packages/frontend/src/pages/match/components/in-game/Playing.tsx
@@ -130,7 +130,10 @@ export default function Playing() {
                   autoFocus
                   onChange={(e) => setAnswer(e.target.value)}
                   onKeyDown={(e) => {
-                    if (e.nativeEvent.isComposing) return;
+                    if (e.nativeEvent.isComposing) {
+                      return;
+                    }
+
                     if (e.key === 'Enter' && answer.trim() !== '' && !isSubmit && !isSubmitting) {
                       onClickSubmitBtn();
                     }

--- a/packages/frontend/src/pages/single-play/components/Playing.tsx
+++ b/packages/frontend/src/pages/single-play/components/Playing.tsx
@@ -73,7 +73,10 @@ export default function Playing() {
                 style={{ fontFamily: 'Orbitron' }}
                 onChange={(e) => setAnswer(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.nativeEvent.isComposing) return;
+                  if (e.nativeEvent.isComposing) {
+                    return;
+                  }
+
                   if (e.key === 'Enter' && answer.trim() !== '' && !isSubmitting) {
                     void onClickSubmitBtn();
                   }


### PR DESCRIPTION
## 📝 개요 (Description)

문제 풀이 UX를 개선합니다.

- **객관식 문항**: 기존 텍스트 나열 + 텍스트 입력 방식에서, A/B/C/D 선택 버튼 UI로 변경하여 직관적인 답안 선택이 가능하도록 수정
- **단답형/서술형 문항**: `Enter` 키로 답안을 제출할 수 있도록 수정

싱글플레이와 실시간 대전 양쪽 모두에 동일하게 적용됩니다.

## 🔗 관련 이슈 (Related Issues)

-   Closes #197

## 🏷️ 작업 유형 (Type of Change)

-   [x] ✨ 기능 추가 (New Feature)
-   [ ] 🐛 버그 수정 (Bug Fix)
-   [ ] ♻️ 리팩토링 (Refactoring)
-   [ ] 📝 문서 업데이트 (Documentation)
-   [ ] 🔧 설정 변경 및 기타 (Config & Other)

## ✅ 체크리스트 (Checklist)

-   [x] 코드가 정상적으로 컴파일/빌드 되나요?
-   [x] 기존 테스트를 통과했나요? (새로운 테스트가 필요하다면 추가했나요?)
-   [x] 스스로 코드를 리뷰했나요? (Self-review)
-   [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
-   [ ] 문서(README 등)에 변경 사항을 업데이트했나요?

## 📸 스크린샷 (Screenshots)

## 🎸 기타 (Etc)

- Hook 파일(`usePlaying`)은 변경 없이, 기존 `setAnswer`와 `onClickSubmitBtn`을 UI 레이어에서 재활용하는 방식으로 구현했습니다.
- 객관식 버튼 선택 후에도 "SUBMIT ANSWER" 버튼을 통해 최종 제출하는 2단계 방식을 유지하여, 실수로 잘못 선택한 경우 변경할 수 있도록 했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 객관식 문제 UI 개선: 선택지 A–D를 클릭 가능한 버튼으로 표시하고 선택 상태를 시각적으로 강조합니다.
  * 주관식은 텍스트 입력 유지하되 Enter 키로 제출 가능하도록 동작을 통일합니다.

* **버그 수정 / 사용성**
  * 제출 중에는 선택지 버튼과 제출 동작을 비활성화해 중복 제출을 방지합니다.
  * 입력 중 조합 문자를 고려한 Enter 제출 처리로 오입력 방지 개선.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->