### PR TITLE
[Fix] 사용자 답안 개행을 위한 CSS 수정

### DIFF
--- a/packages/frontend/src/pages/match/components/MatchResult.tsx
+++ b/packages/frontend/src/pages/match/components/MatchResult.tsx
@@ -255,7 +255,10 @@ export default function MatchResult() {
                     <div className="font-bold text-cyan-300" style={{ fontFamily: 'Orbitron' }}>
                       You:
                     </div>
-                    <div className="text-white" style={{ fontFamily: 'Orbitron' }}>
+                    <div
+                      className="whitespace-pre-wrap text-white"
+                      style={{ fontFamily: 'Orbitron' }}
+                    >
                       {result.myAnswer}
                     </div>
                   </div>
@@ -265,20 +268,29 @@ export default function MatchResult() {
                     <div className="font-bold text-pink-300" style={{ fontFamily: 'Orbitron' }}>
                       Opponent:
                     </div>
-                    <div className="text-white" style={{ fontFamily: 'Orbitron' }}>
+                    <div
+                      className="whitespace-pre-wrap text-white"
+                      style={{ fontFamily: 'Orbitron' }}
+                    >
                       {result.opponentAnswer}
                     </div>
                   </div>
                 </div>
 
                 {/* Best Answer */}
-                <div className="gap-1 border border-amber-400 bg-amber-500/20 p-2">
+                <div className="flex flex-col gap-1 border border-amber-400 bg-amber-500/20 p-2">
                   <span
                     className="text-xs font-bold text-amber-400"
                     style={{ fontFamily: 'Orbitron' }}
                   >
                     <i className="ri-lightbulb-line mr-1" />
-                    Answer: {result.bestAnswer}
+                    Answer
+                  </span>
+                  <span
+                    className="whitespace-pre-wrap text-xs text-white"
+                    style={{ fontFamily: 'Orbitron' }}
+                  >
+                    {result.bestAnswer}
                   </span>
                 </div>
 
@@ -292,7 +304,10 @@ export default function MatchResult() {
                       <i className="ri-robot-2-line mr-1" />
                       AI Feedback
                     </span>
-                    <span className="text-xs text-white" style={{ fontFamily: 'Orbitron' }}>
+                    <span
+                      className="whitespace-pre-wrap text-xs text-white"
+                      style={{ fontFamily: 'Orbitron' }}
+                    >
                       {result.explanation}
                     </span>
                   </div>

--- a/packages/frontend/src/pages/match/components/in-game/RoundResult.tsx
+++ b/packages/frontend/src/pages/match/components/in-game/RoundResult.tsx
@@ -40,7 +40,10 @@ export default function RoundResult() {
               <div className="text-xs text-purple-300" style={{ fontFamily: 'Orbitron' }}>
                 YOUR ANSWER
               </div>
-              <div className="text-base text-white" style={{ fontFamily: 'Orbitron' }}>
+              <div
+                className="whitespace-pre-wrap text-base text-white"
+                style={{ fontFamily: 'Orbitron' }}
+              >
                 {myAnswer}
               </div>
             </div>
@@ -79,7 +82,10 @@ export default function RoundResult() {
               <div className="mb-1 text-xs text-purple-300" style={{ fontFamily: 'Orbitron' }}>
                 OPPONENT ANSWER
               </div>
-              <div className="text-base text-white" style={{ fontFamily: 'Orbitron' }}>
+              <div
+                className="whitespace-pre-wrap text-base text-white"
+                style={{ fontFamily: 'Orbitron' }}
+              >
                 {opponentAnswer}
               </div>
             </div>
@@ -111,7 +117,10 @@ export default function RoundResult() {
             <i className="ri-lightbulb-line mr-2" />
             CORRECT ANSWER
           </div>
-          <div className="text-base text-white" style={{ fontFamily: 'Orbitron' }}>
+          <div
+            className="whitespace-pre-wrap text-base text-white"
+            style={{ fontFamily: 'Orbitron' }}
+          >
             {bestAnswer}
           </div>
         </div>
@@ -122,7 +131,10 @@ export default function RoundResult() {
             <i className="ri-robot-2-line mr-2" />
             AI Feedback
           </div>
-          <div className="text-base text-white" style={{ fontFamily: 'Orbitron' }}>
+          <div
+            className="whitespace-pre-wrap text-base text-white"
+            style={{ fontFamily: 'Orbitron' }}
+          >
             {explanation}
           </div>
         </div>

--- a/packages/frontend/src/pages/single-play/components/RoundResult.tsx
+++ b/packages/frontend/src/pages/single-play/components/RoundResult.tsx
@@ -67,7 +67,10 @@ export default function RoundResult() {
             <div className="text-xs text-purple-300" style={{ fontFamily: 'Orbitron' }}>
               YOUR ANSWER
             </div>
-            <div className="text-base text-white" style={{ fontFamily: 'Orbitron' }}>
+            <div
+              className="whitespace-pre-wrap text-base text-white"
+              style={{ fontFamily: 'Orbitron' }}
+            >
               {submittedAnswer}
             </div>
           </div>
@@ -95,7 +98,10 @@ export default function RoundResult() {
             <i className="ri-lightbulb-line mr-2" />
             CORRECT ANSWER
           </div>
-          <div className="text-base text-white" style={{ fontFamily: 'Orbitron' }}>
+          <div
+            className="whitespace-pre-wrap text-base text-white"
+            style={{ fontFamily: 'Orbitron' }}
+          >
             {curQuestion?.type === 'multiple_choice' && curQuestion?.answer}
             {curQuestion?.type === 'short_answer' && curQuestion?.answer}
             {curQuestion?.type === 'essay' && curQuestion?.sampleAnswer}
@@ -108,7 +114,10 @@ export default function RoundResult() {
             <i className="ri-robot-2-line mr-2" />
             AI Feedback
           </div>
-          <div className="text-base text-white" style={{ fontFamily: 'Orbitron' }}>
+          <div
+            className="whitespace-pre-wrap text-base text-white"
+            style={{ fontFamily: 'Orbitron' }}
+          >
             {aiFeedback}
           </div>
         </div>


### PR DESCRIPTION
## 📝 개요 (Description)

결과 화면에서 사용자 답안의 개행이 반영되지 않는 문제를 수정합니다.

기존에는 서술형 답안 등에서 사용자가 입력한 줄바꿈(`\n`)이 무시되어 한 줄로 표시되었습니다. `whitespace-pre-wrap` CSS를 적용하여 개행이 정상적으로 렌더링되도록 수정했습니다.

**적용 범위:**
- 싱글플레이 라운드 결과: 사용자 답안, 정답, AI 피드백
- 실시간 대전 라운드 결과: 내 답안, 상대 답안, 정답, AI 피드백
- 실시간 대전 매치 결과 (히스토리): 양측 답안, 정답, AI 피드백

## 🔗 관련 이슈 (Related Issues)

-   Closes #201

## 🏷️ 작업 유형 (Type of Change)

-   [ ] ✨ 기능 추가 (New Feature)
-   [x] 🐛 버그 수정 (Bug Fix)
-   [ ] ♻️ 리팩토링 (Refactoring)
-   [ ] 📝 문서 업데이트 (Documentation)
-   [ ] 🔧 설정 변경 및 기타 (Config & Other)

## ✅ 체크리스트 (Checklist)

-   [x] 코드가 정상적으로 컴파일/빌드 되나요?
-   [x] 기존 테스트를 통과했나요? (새로운 테스트가 필요하다면 추가했나요?)
-   [x] 스스로 코드를 리뷰했나요? (Self-review)
-   [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
-   [ ] 문서(README 등)에 변경 사항을 업데이트했나요?

## 📸 스크린샷 (Screenshots)

<img width="1175" height="984" alt="image" src="https://github.com/user-attachments/assets/13dea96a-37be-4e42-96f5-4abd52709489" />


## 🎸 기타 (Etc)

- 매치 결과 히스토리의 "Best Answer" 섹션은 기존에 레이블과 값이 한 줄에 있어 개행 지원이 어려웠습니다. AI Feedback 섹션과 동일하게 레이블/값 분리 구조로 변경하여 개행을 지원하도록 했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 답변 및 피드백 텍스트 블록의 줄 바꿈과 공백 처리 개선
  * 여러 경기 결과 화면에서 텍스한 텍스트 표시 일관성 강화
  * 멀티라인 콘텐츠의 올바른 줄 바꿈 및 서식 보존 처리

* **스타일**
  * 경기 결과 화면의 레이아웃 및 텍스트 렌더링 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->