### PR TITLE
[FEAT] 싱글플레이 채점중 UI 추가

### DIFF
--- a/packages/frontend/src/pages/single-play/components/Playing.tsx
+++ b/packages/frontend/src/pages/single-play/components/Playing.tsx
@@ -45,56 +45,88 @@ export default function Playing() {
           </div>
 
           {/* Answer Input */}
-          <div className="flex flex-col gap-4">
-            {curQuestion?.type === 'multiple_choice' ? (
-              <div className="flex flex-col gap-3">
-                {(['A', 'B', 'C', 'D'] as const).map((key) => (
-                  <button
-                    key={key}
-                    className={`flex items-center gap-4 border-2 px-4 py-3 text-left text-base text-white transition-all duration-200 hover:border-purple-400 ${answer === key ? 'border-cyan-400 bg-cyan-500/20 shadow-lg shadow-cyan-500/30' : 'border-slate-500 bg-slate-700/50'}`}
+          {isSubmitting && curQuestion?.type !== 'multiple_choice' ? (
+            <div className="flex justify-center py-12">
+              <div className="relative flex flex-col items-center gap-6 border-4 border-cyan-400 bg-gradient-to-br from-slate-900/95 via-purple-900/30 to-slate-900/95 p-12 shadow-2xl shadow-cyan-500/40">
+                <div className="relative">
+                  <div className="h-24 w-24 animate-spin rounded-full border-8 border-slate-700 border-t-cyan-400 shadow-lg shadow-cyan-400/50" />
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <i className="ri-quill-pen-line text-5xl text-cyan-400" />
+                  </div>
+                </div>
+                <div className="flex flex-col items-center gap-2">
+                  <p
+                    className="text-3xl font-bold text-cyan-300"
                     style={{ fontFamily: 'Orbitron' }}
-                    onClick={() => setAnswer(key)}
-                    disabled={isSubmitting}
                   >
-                    <span
-                      className={`flex h-8 w-8 shrink-0 items-center justify-center border-2 text-sm font-bold ${answer === key ? 'border-cyan-300 bg-cyan-500 text-white' : 'border-slate-400 bg-slate-600 text-slate-300'}`}
-                    >
-                      {key}
+                    GRADING IN PROGRESS
+                  </p>
+                  <p
+                    className="flex items-center gap-1 text-lg text-slate-400"
+                    style={{ fontFamily: 'Orbitron' }}
+                  >
+                    답안을 채점하고 있습니다
+                    <span className="flex">
+                      <span className="animate-[bounce_1.4s_ease-in-out_0s_infinite]">.</span>
+                      <span className="animate-[bounce_1.4s_ease-in-out_0.2s_infinite]">.</span>
+                      <span className="animate-[bounce_1.4s_ease-in-out_0.4s_infinite]">.</span>
                     </span>
-                    <span>{curQuestion.options[key]}</span>
-                  </button>
-                ))}
+                  </p>
+                </div>
+                <div className="absolute inset-0 -z-10 animate-pulse border-4 border-cyan-400/30 blur-xl" />
               </div>
-            ) : (
-              <input
-                type="text"
-                placeholder="Type your answer here..."
-                className="border-2 border-cyan-400 bg-slate-700 px-4 py-3 text-base text-white focus:border-cyan-300 focus:outline-none focus:ring-2 focus:ring-cyan-500/50"
-                style={{ fontFamily: 'Orbitron' }}
-                onChange={(e) => setAnswer(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.nativeEvent.isComposing) {
-                    return;
-                  }
+            </div>
+          ) : (
+            <div className="flex flex-col gap-4">
+              {curQuestion?.type === 'multiple_choice' ? (
+                <div className="flex flex-col gap-3">
+                  {(['A', 'B', 'C', 'D'] as const).map((key) => (
+                    <button
+                      key={key}
+                      className={`flex items-center gap-4 border-2 px-4 py-3 text-left text-base text-white transition-all duration-200 hover:border-purple-400 ${answer === key ? 'border-cyan-400 bg-cyan-500/20 shadow-lg shadow-cyan-500/30' : 'border-slate-500 bg-slate-700/50'}`}
+                      style={{ fontFamily: 'Orbitron' }}
+                      onClick={() => setAnswer(key)}
+                      disabled={isSubmitting}
+                    >
+                      <span
+                        className={`flex h-8 w-8 shrink-0 items-center justify-center border-2 text-sm font-bold ${answer === key ? 'border-cyan-300 bg-cyan-500 text-white' : 'border-slate-400 bg-slate-600 text-slate-300'}`}
+                      >
+                        {key}
+                      </span>
+                      <span>{curQuestion.options[key]}</span>
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <input
+                  type="text"
+                  placeholder="Type your answer here..."
+                  className="border-2 border-cyan-400 bg-slate-700 px-4 py-3 text-base text-white focus:border-cyan-300 focus:outline-none focus:ring-2 focus:ring-cyan-500/50"
+                  style={{ fontFamily: 'Orbitron' }}
+                  onChange={(e) => setAnswer(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.nativeEvent.isComposing) {
+                      return;
+                    }
 
-                  if (e.key === 'Enter' && answer.trim() !== '' && !isSubmitting) {
-                    void onClickSubmitBtn();
-                  }
-                }}
-                autoFocus
-                disabled={isSubmitting}
-              />
-            )}
-            <button
-              className="w-full border-4 border-cyan-300 bg-gradient-to-r from-cyan-500 to-blue-500 py-3 font-bold text-white shadow-lg shadow-cyan-500/50 transition-all duration-200 enabled:hover:scale-105 enabled:hover:from-cyan-400 enabled:hover:to-blue-400 disabled:border-cyan-300/40 disabled:from-cyan-900/50 disabled:to-blue-900/50 disabled:text-white/70 disabled:shadow-cyan-500/20"
-              style={{ fontFamily: 'Orbitron' }}
-              onClick={onClickSubmitBtn}
-              disabled={isSubmitting || answer.trim() === ''}
-            >
-              <i className="ri-send-plane-fill mr-2" />
-              SUBMIT ANSWER
-            </button>
-          </div>
+                    if (e.key === 'Enter' && answer.trim() !== '') {
+                      void onClickSubmitBtn();
+                    }
+                  }}
+                  autoFocus
+                />
+              )}
+              <button
+                className="w-full border-4 border-cyan-300 bg-gradient-to-r from-cyan-500 to-blue-500 py-3 font-bold text-white shadow-lg shadow-cyan-500/50 transition-all duration-200 enabled:hover:scale-105 enabled:hover:from-cyan-400 enabled:hover:to-blue-400 disabled:border-cyan-300/40 disabled:from-cyan-900/50 disabled:to-blue-900/50 disabled:text-white/70 disabled:shadow-cyan-500/20"
+                style={{ fontFamily: 'Orbitron' }}
+                onClick={onClickSubmitBtn}
+                disabled={isSubmitting || answer.trim() === ''}
+              >
+                <i className="ri-send-plane-fill mr-2" />
+                SUBMIT ANSWER
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION


## 📝 개요 (Description)

- 채점 진행 중일 때 시각적 피드백을 제공하는 대기 UI 추가
- "채점 중" 메시지와 애니메이션 효과 제공
- 기존 정답 입력 로직에 조건 분기 추가
- 사용자 경험 개선을 위한 UI/UX 업데이트

## 🔗 관련 이슈 (Related Issues)

-   Closes #231

## 🏷️ 작업 유형 (Type of Change)
-   [x] ✨ 기능 추가 (New Feature)
-   [ ] 🐛 버그 수정 (Bug Fix)
-   [ ] ♻️ 리팩토링 (Refactoring)
-   [ ] 📝 문서 업데이트 (Documentation)
-   [ ] 🔧 설정 변경 및 기타 (Config & Other)

## ✅ 체크리스트 (Checklist)
-   [x] 코드가 정상적으로 컴파일/빌드 되나요?
-   [x] 기존 테스트를 통과했나요? (새로운 테스트가 필요하다면 추가했나요?)
-   [x] 스스로 코드를 리뷰했나요? (Self-review)
-   [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
-   [ ] 문서(README 등)에 변경 사항을 업데이트했나요?

## 📸 스크린샷 (Screenshots)

<img width="1057" height="541" alt="image" src="https://github.com/user-attachments/assets/54c763a2-eff5-42a9-999f-6e4510fe4956" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채점 진행 중 상태를 시각적으로 표시하는 진행 중 화면 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->