### PR TITLE
 [REFACTOR] 중복된 난이도 매핑 로직 통합

### DIFF
--- a/packages/backend/src/common/utils/difficulty.util.ts
+++ b/packages/backend/src/common/utils/difficulty.util.ts
@@ -1,0 +1,53 @@
+export type Difficulty = 'easy' | 'medium' | 'hard';
+
+/**
+ * 숫자 난이도(1-5)를 문자열 난이도로 매핑
+ * 1-2: easy, 3: medium, 4-5: hard
+ *
+ * @param numDifficulty - 숫자 난이도 (1-5), null인 경우 medium 반환
+ * @returns 문자열 난이도
+ */
+export function mapDifficulty(numDifficulty: number | null): Difficulty {
+  if (!numDifficulty) {
+    return 'medium';
+  }
+
+  if (numDifficulty <= 2) {
+    return 'easy';
+  }
+
+  if (numDifficulty === 3) {
+    return 'medium';
+  }
+
+  return 'hard';
+}
+
+/**
+ * 문자열 난이도를 대문자로 표시 (UI용)
+ *
+ * @param numDifficulty - 숫자 난이도 (1-5)
+ * @returns 대문자 난이도 문자열 ('Easy' | 'Medium' | 'Hard')
+ */
+export function mapDifficultyDisplay(numDifficulty: number | null): string {
+  const difficulty = mapDifficulty(numDifficulty);
+
+  return difficulty.charAt(0).toUpperCase() + difficulty.slice(1);
+}
+
+/**
+ * 문자열 난이도를 숫자 범위로 변환
+ *
+ * @param difficulty - 문자열 난이도
+ * @returns 숫자 범위 { min, max }
+ */
+export function getDifficultyRange(difficulty: Difficulty): { min: number; max: number } {
+  switch (difficulty) {
+    case 'easy':
+      return { min: 1, max: 2 };
+    case 'medium':
+      return { min: 3, max: 3 };
+    case 'hard':
+      return { min: 4, max: 5 };
+  }
+}

--- a/packages/backend/src/game/round-progression.service.ts
+++ b/packages/backend/src/game/round-progression.service.ts
@@ -4,11 +4,12 @@ import { RoundTimer } from './round-timer';
 import { QuizService } from '../quiz/quiz.service';
 import { GameSessionManager } from './game-session-manager';
 import { MatchPersistenceService } from './match-persistence.service';
-import { Difficulty, getValidQuestionType, ROUND_DURATIONS } from './round-timer.constants';
+import { getValidQuestionType, ROUND_DURATIONS } from './round-timer.constants';
 import { SPEED_BONUS } from '../quiz/quiz.constants';
 import { transformQuestionForClient } from './transformers/question.transformer';
 import { FinalResult } from './interfaces/game.interfaces';
 import { RoundResult } from '../quiz/quiz.types';
+import { mapDifficulty } from '../common/utils/difficulty.util';
 
 @Injectable()
 export class RoundProgressionService {
@@ -92,17 +93,7 @@ export class RoundProgressionService {
       });
 
       // 난이도 매핑 (DB의 숫자 난이도 -> 문자열)
-      const difficultyNum = question.difficulty || 3;
-      let difficulty: Difficulty;
-
-      if (difficultyNum <= 2) {
-        difficulty = 'easy';
-      } else if (difficultyNum === 3) {
-        difficulty = 'medium';
-      } else {
-        difficulty = 'hard';
-      }
-
+      const difficulty = mapDifficulty(question.difficulty);
       const questionType = getValidQuestionType(question.questionType);
       const questionDuration = ROUND_DURATIONS.QUESTION[questionType][difficulty];
 

--- a/packages/backend/src/game/transformers/question.transformer.ts
+++ b/packages/backend/src/game/transformers/question.transformer.ts
@@ -1,5 +1,6 @@
 import { Question as QuestionEntity } from '../../quiz/entity';
 import { SCORE_MAP } from '../../quiz/quiz.constants';
+import { mapDifficulty, mapDifficultyDisplay } from '../../common/utils/difficulty.util';
 
 /**
  * DB Question 엔티티를 클라이언트 API 형식으로 변환
@@ -17,7 +18,7 @@ function transformQuestionForClient(
     | { type: 'short'; question: string }
     | { type: 'essay'; question: string };
 } {
-  const difficulty = mapDifficulty(question.difficulty);
+  const difficulty = mapDifficultyDisplay(question.difficulty);
   const point = getPointScore(question.difficulty);
 
   switch (question.questionType) {
@@ -94,41 +95,12 @@ function parseContent(content: string | object): {
 }
 
 /**
- * 숫자 난이도를 문자열로 매핑
- */
-function mapDifficulty(numDifficulty: number | null): string {
-  if (!numDifficulty) {
-    return 'Medium';
-  }
-
-  if (numDifficulty <= 2) {
-    return 'Easy';
-  }
-
-  if (numDifficulty === 3) {
-    return 'Medium';
-  }
-
-  return 'Hard';
-}
-
-/**
  * 난이도에 따른 만점 점수 계산
  */
 function getPointScore(numDifficulty: number | null): number {
-  if (!numDifficulty) {
-    return SCORE_MAP.medium;
-  }
+  const difficulty = mapDifficulty(numDifficulty);
 
-  if (numDifficulty <= 2) {
-    return SCORE_MAP.easy;
-  }
-
-  if (numDifficulty === 3) {
-    return SCORE_MAP.medium;
-  }
-
-  return SCORE_MAP.hard;
+  return SCORE_MAP[difficulty];
 }
 
 export { transformQuestionForClient };

--- a/packages/backend/src/problem-bank/problem-bank.service.ts
+++ b/packages/backend/src/problem-bank/problem-bank.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { UserProblemBank } from './entity/user-problem-bank.entity';
+import { UserProblemBank } from './entity';
 import { DifficultyFilter, GetProblemBankQueryDto } from './dto/get-problem-bank-query.dto';
 import {
   ProblemBankItemDto,
@@ -9,6 +9,7 @@ import {
   ProblemBankStatisticsDto,
 } from './dto/problem-bank-response.dto';
 import { UpdateBookmarkDto } from './dto/update-bookmark.dto';
+import { Difficulty, getDifficultyRange, mapDifficulty } from '../common/utils/difficulty.util';
 
 @Injectable()
 export class ProblemBankService {
@@ -43,7 +44,7 @@ export class ProblemBankService {
     }
 
     if (query.difficulty) {
-      const difficultyRange = this.getDifficultyRange(query.difficulty);
+      const difficultyRange = this.getDifficultyRangeFromFilter(query.difficulty);
       queryBuilder.andWhere('q.difficulty BETWEEN :min AND :max', difficultyRange);
     }
 
@@ -133,31 +134,8 @@ export class ProblemBankService {
     await this.problemBankRepository.save(problemBank);
   }
 
-  private getDifficultyRange(difficulty: DifficultyFilter): { min: number; max: number } {
-    switch (difficulty) {
-      case DifficultyFilter.EASY:
-        return { min: 1, max: 2 };
-      case DifficultyFilter.MEDIUM:
-        return { min: 3, max: 3 };
-      case DifficultyFilter.HARD:
-        return { min: 4, max: 5 };
-    }
-  }
-
-  private mapDifficulty(numDifficulty: number | null): 'easy' | 'medium' | 'hard' {
-    if (!numDifficulty) {
-      return 'medium';
-    }
-
-    if (numDifficulty <= 2) {
-      return 'easy';
-    }
-
-    if (numDifficulty === 3) {
-      return 'medium';
-    }
-
-    return 'hard';
+  private getDifficultyRangeFromFilter(difficulty: DifficultyFilter): { min: number; max: number } {
+    return getDifficultyRange(difficulty.toLowerCase() as Difficulty);
   }
 
   private extractQuestionText(content: string | object): string {
@@ -196,7 +174,7 @@ export class ProblemBankService {
       questionId: item.questionId,
       questionContent: this.extractQuestionText(item.question.content),
       categories: this.extractCategories(item),
-      difficulty: this.mapDifficulty(item.question.difficulty),
+      difficulty: mapDifficulty(item.question.difficulty),
       answerStatus: item.answerStatus || 'incorrect', // null 대체값
       isBookmarked: item.isBookmarked ?? false, // null을 false로 처리
       userAnswer: item.userAnswer || '',

--- a/packages/backend/src/quiz/quiz.constants.ts
+++ b/packages/backend/src/quiz/quiz.constants.ts
@@ -1,5 +1,7 @@
 import { Difficulty } from './quiz.types';
 
+export { mapDifficulty } from '../common/utils/difficulty.util';
+
 export const SCORE_MAP: Record<Difficulty, number> = {
   easy: 10,
   medium: 20,
@@ -7,26 +9,6 @@ export const SCORE_MAP: Record<Difficulty, number> = {
 };
 
 export const SPEED_BONUS = 5;
-
-/**
- * 숫자 난이도를 문자열 난이도로 매핑
- * 1-2: easy, 3: medium, 4-5: hard
- */
-export function mapDifficulty(numDifficulty: number | null): Difficulty {
-  if (!numDifficulty) {
-    return 'medium';
-  }
-
-  if (numDifficulty <= 2) {
-    return 'easy';
-  }
-
-  if (numDifficulty === 3) {
-    return 'medium';
-  }
-
-  return 'hard';
-}
 
 /**
  * Quiz 서비스 상수 정의


### PR DESCRIPTION


## 📝 개요 (Description)
- mapDifficulty 함수를 `difficulty.util.ts`로 이동하여 재사용성 향상
- 기존 난이도 매핑 및 범위 계산 함수들을 통합/삭제하고 공통 유틸 함수 사용
- quiz.constants.ts와 question.transformer.ts 등 관련 파일에서 중복 코드 제거
- 문제 은행 서비스에서 난이도 필터 관련 함수 간소화 및 가독성 개선

## 🔗 관련 이슈 (Related Issues)
-   Closes #235 

## 🏷️ 작업 유형 (Type of Change)
-   [ ] ✨ 기능 추가 (New Feature)
-   [ ] 🐛 버그 수정 (Bug Fix)
-   [x] ♻️ 리팩토링 (Refactoring)
-   [ ] 📝 문서 업데이트 (Documentation)
-   [ ] 🔧 설정 변경 및 기타 (Config & Other)

## ✅ 체크리스트 (Checklist)
-   [x] 코드가 정상적으로 컴파일/빌드 되나요?
-   [x] 기존 테스트를 통과했나요? (새로운 테스트가 필요하다면 추가했나요?)
-   [x] 스스로 코드를 리뷰했나요? (Self-review)
-   [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
-   [ ] 문서(README 등)에 변경 사항을 업데이트했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 백엔드 난이도 처리 로직을 새로운 공유 유틸리티로 통합하여 코드 중복을 제거했습니다. 여러 모듈에서 난이도 매핑 기능이 표준화되어 유지보수성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->