### PR TITLE
[REFACTOR] 리더보드 조회 쿼리 최적화

### DIFF
--- a/packages/backend/src/leaderboard/leaderboard.service.ts
+++ b/packages/backend/src/leaderboard/leaderboard.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Brackets, Repository } from 'typeorm';
 import { UserStatistics } from '../user/entity/user-statistics.entity';
 import { UserProblemBank } from '../problem-bank/entity/user-problem-bank.entity';
 import { Tier } from '../tier/entity/tier.entity';
@@ -148,27 +148,32 @@ export class LeaderboardService {
     const tierPoint = Number(myStats.tierPoint);
     const winCount = Number(myStats.winCount);
     const loseCount = Number(myStats.loseCount);
+    const totalGames = winCount + loseCount;
 
-    // RANK() 윈도우 함수를 사용하여 DB에서 직접 순위 계산
-    const result: Array<{ rank: string | number }> = await this.userStatisticsRepository.query(
-      `
-      SELECT rank FROM (
-        SELECT
-          user_id,
-          RANK() OVER (
-            ORDER BY
-              tier_point DESC,
-              (CASE WHEN win_count + lose_count > 0 THEN win_count * 1.0 / (win_count + lose_count) ELSE 0 END) DESC,
-              (win_count + lose_count) DESC
-          ) as rank
-        FROM user_statistics
-      ) as ranked
-      WHERE user_id = $1
-      `,
-      [userId],
-    );
+    const winRateExpr =
+      'CASE WHEN us.winCount + us.loseCount > 0 THEN us.winCount * 1.0 / (us.winCount + us.loseCount) ELSE 0 END';
+    const myWinRateExpr = totalGames > 0 ? ':winCount * 1.0 / :totalGames' : '0';
 
-    const rank = result[0] ? Number(result[0].rank) : 0;
+    const result = await this.userStatisticsRepository
+      .createQueryBuilder('us')
+      .select('COUNT(*) + 1', 'rank')
+      .where('us.tierPoint > :tierPoint')
+      .orWhere(
+        new Brackets((qb) => {
+          qb.where('us.tierPoint = :tierPoint').andWhere(`${winRateExpr} > ${myWinRateExpr}`);
+        }),
+      )
+      .orWhere(
+        new Brackets((qb) => {
+          qb.where('us.tierPoint = :tierPoint')
+            .andWhere(`${winRateExpr} = ${myWinRateExpr}`)
+            .andWhere('us.winCount + us.loseCount > :totalGames');
+        }),
+      )
+      .setParameters({ tierPoint, winCount, totalGames })
+      .getRawOne<{ rank: string }>();
+
+    const rank = result ? Number(result.rank) : 0;
 
     return {
       rank,
@@ -292,36 +297,46 @@ export class LeaderboardService {
     const solvedCount = Number(myStats.solvedCount);
     const correctCount = Number(myStats.correctCount);
 
-    // RANK() 윈도우 함수를 사용하여 DB에서 직접 순위 계산
-    const result: Array<{ rank: string | number }> = await this.userStatisticsRepository.query(
-      `
-      SELECT rank FROM (
-        SELECT
-          us.user_id,
-          RANK() OVER (
-            ORDER BY
-              us.exp_point DESC,
-              (CASE WHEN COALESCE(pb_stats.solved_count, 0) > 0 THEN COALESCE(pb_stats.correct_count, 0) * 1.0 / pb_stats.solved_count ELSE 0 END) DESC,
-              COALESCE(pb_stats.solved_count, 0) DESC
-          ) as rank
-        FROM user_statistics us
-        LEFT JOIN (
-          SELECT
-            pb.user_id,
-            COUNT(*) as solved_count,
-            SUM(CASE WHEN pb.answer_status = 'correct' THEN 1 ELSE 0 END) as correct_count
-          FROM user_problem_banks pb
-          INNER JOIN matches m ON m.id = pb.match_id
-          WHERE m.match_type = 'single'
-          GROUP BY pb.user_id
-        ) pb_stats ON us.user_id = pb_stats.user_id
-      ) as ranked
-      WHERE user_id = $1
-      `,
-      [userId],
-    );
+    const correctRateExpr =
+      'CASE WHEN COALESCE(pb_stats.solved_count, 0) > 0 THEN COALESCE(pb_stats.correct_count, 0) * 1.0 / pb_stats.solved_count ELSE 0 END';
+    const myCorrectRateExpr = solvedCount > 0 ? ':correctCount * 1.0 / :solvedCount' : '0';
 
-    const rank = result[0] ? Number(result[0].rank) : 0;
+    const result = await this.userStatisticsRepository
+      .createQueryBuilder('us')
+      .leftJoin(
+        (qb) =>
+          qb
+            .select('pb.userId', 'odbc')
+            .addSelect('COUNT(*)', 'solved_count')
+            .addSelect(
+              "SUM(CASE WHEN pb.answerStatus = 'correct' THEN 1 ELSE 0 END)",
+              'correct_count',
+            )
+            .from(UserProblemBank, 'pb')
+            .innerJoin('pb.match', 'm')
+            .where("m.matchType = 'single'")
+            .groupBy('pb.userId'),
+        'pb_stats',
+        'us.userId = pb_stats.odbc',
+      )
+      .select('COUNT(*) + 1', 'rank')
+      .where('us.expPoint > :expPoint')
+      .orWhere(
+        new Brackets((qb) => {
+          qb.where('us.expPoint = :expPoint').andWhere(`${correctRateExpr} > ${myCorrectRateExpr}`);
+        }),
+      )
+      .orWhere(
+        new Brackets((qb) => {
+          qb.where('us.expPoint = :expPoint')
+            .andWhere(`${correctRateExpr} = ${myCorrectRateExpr}`)
+            .andWhere('COALESCE(pb_stats.solved_count, 0) > :solvedCount');
+        }),
+      )
+      .setParameters({ expPoint, correctCount, solvedCount })
+      .getRawOne<{ rank: string }>();
+
+    const rank = result ? Number(result.rank) : 0;
 
     return {
       rank,

--- a/packages/backend/src/single-play/single-play.service.ts
+++ b/packages/backend/src/single-play/single-play.service.ts
@@ -288,14 +288,18 @@ export class SinglePlayService {
         aiFeedback: grade.feedback,
       });
 
+      const isCorrect = answerStatus === 'correct';
+
       const result: [{ exp_point: number }[], number] = await manager.query(
         `
         UPDATE user_statistics
-        SET exp_point = COALESCE(exp_point, 0) + $1
+        SET exp_point = COALESCE(exp_point, 0) + $1,
+            solved_count = solved_count + 1,
+            correct_count = correct_count + $3
         WHERE user_id = $2
         RETURNING exp_point
         `,
-        [finalScore, uid],
+        [finalScore, uid, isCorrect ? 1 : 0],
       );
 
       const rows = result[0];

--- a/packages/backend/src/user/entity/user-statistics.entity.ts
+++ b/packages/backend/src/user/entity/user-statistics.entity.ts
@@ -26,6 +26,24 @@ export class UserStatistics {
   })
   expPoint: number | null;
 
+  @Column({
+    type: 'int',
+    nullable: false,
+    name: 'solved_count',
+    default: 0,
+    comment: '싱글플레이 푼 문제 수',
+  })
+  solvedCount: number;
+
+  @Column({
+    type: 'int',
+    nullable: false,
+    name: 'correct_count',
+    default: 0,
+    comment: '싱글플레이 정답 수',
+  })
+  correctCount: number;
+
   @Column({ type: 'bigint', nullable: false, name: 'user_id' })
   userId: number;
 

--- a/packages/backend/test/leaderboard/leaderboard.service.spec.ts
+++ b/packages/backend/test/leaderboard/leaderboard.service.spec.ts
@@ -20,10 +20,12 @@ describe('LeaderboardService', () => {
     addSelect: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
+    orWhere: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
     addOrderBy: jest.fn().mockReturnThis(),
     groupBy: jest.fn().mockReturnThis(),
     limit: jest.fn().mockReturnThis(),
+    setParameters: jest.fn().mockReturnThis(),
     getOne: jest.fn().mockResolvedValue(null),
     getRawOne: jest.fn().mockResolvedValue(null),
     getCount: jest.fn().mockResolvedValue(0),
@@ -62,12 +64,14 @@ describe('LeaderboardService', () => {
       const myStatsQB = createMockQueryBuilder({
         getRawOne: jest.fn().mockResolvedValue(myStats),
       });
+      const rankQB = createMockQueryBuilder({
+        getRawOne: jest.fn().mockResolvedValue({ rank: String(myRank) }),
+      });
 
       mockUserStatisticsRepository.createQueryBuilder
         .mockReturnValueOnce(rankingsQB)
-        .mockReturnValueOnce(myStatsQB);
-
-      mockUserStatisticsRepository.query.mockResolvedValue([{ rank: String(myRank) }]);
+        .mockReturnValueOnce(myStatsQB)
+        .mockReturnValueOnce(rankQB);
     };
 
     it('랭킹 목록과 내 순위를 반환한다', async () => {
@@ -298,12 +302,14 @@ describe('LeaderboardService', () => {
       const myStatsQB = createMockQueryBuilder({
         getRawOne: jest.fn().mockResolvedValue(myStats),
       });
+      const rankQB = createMockQueryBuilder({
+        getRawOne: jest.fn().mockResolvedValue({ rank: String(myRank) }),
+      });
 
       mockUserStatisticsRepository.createQueryBuilder
         .mockReturnValueOnce(rankingsQB)
-        .mockReturnValueOnce(myStatsQB);
-
-      mockUserStatisticsRepository.query.mockResolvedValue([{ rank: String(myRank) }]);
+        .mockReturnValueOnce(myStatsQB)
+        .mockReturnValueOnce(rankQB);
     };
 
     it('랭킹 목록과 내 순위를 반환한다', async () => {
@@ -524,12 +530,14 @@ describe('LeaderboardService', () => {
           tier: 'silver',
         }),
       });
+      const rankQB = createMockQueryBuilder({
+        getRawOne: jest.fn().mockResolvedValue({ rank: '1' }),
+      });
 
       mockUserStatisticsRepository.createQueryBuilder
         .mockReturnValueOnce(rankingsQB)
-        .mockReturnValueOnce(myStatsQB);
-
-      mockUserStatisticsRepository.query.mockResolvedValue([{ rank: '1' }]);
+        .mockReturnValueOnce(myStatsQB)
+        .mockReturnValueOnce(rankQB);
 
       const result = (await service.getLeaderboard(
         MatchType.MULTI,
@@ -590,12 +598,14 @@ describe('LeaderboardService', () => {
       const myStatsQB = createMockQueryBuilder({
         getRawOne: jest.fn().mockResolvedValue(myStats),
       });
+      const rankQB = createMockQueryBuilder({
+        getRawOne: jest.fn().mockResolvedValue({ rank: '4' }),
+      });
 
       mockUserStatisticsRepository.createQueryBuilder
         .mockReturnValueOnce(rankingsQB)
-        .mockReturnValueOnce(myStatsQB);
-
-      mockUserStatisticsRepository.query.mockResolvedValue([{ rank: '4' }]);
+        .mockReturnValueOnce(myStatsQB)
+        .mockReturnValueOnce(rankQB);
 
       const result = (await service.getLeaderboard(
         MatchType.MULTI,

--- a/packages/backend/test/single-play.service.spec.ts
+++ b/packages/backend/test/single-play.service.spec.ts
@@ -240,10 +240,9 @@ describe('SinglePlayService', () => {
         expect.objectContaining({ where: { id: matchId } }),
       );
 
-      // solved_count, correct_count 업데이트 검증 (정답이므로 correct_count + 1)
       expect(mockManager.query).toHaveBeenCalledWith(
         expect.stringContaining('solved_count = solved_count + 1'),
-        expect.arrayContaining([1]), // isCorrect ? 1 : 0 → 정답이므로 1
+        [expect.any(Number), expect.any(Number), 1],
       );
     });
 
@@ -285,11 +284,9 @@ describe('SinglePlayService', () => {
       const result = await service.submitAnswer(userId, matchId, questionId, answer);
 
       expect(result.grade.isCorrect).toBe(false);
-
-      // solved_count는 항상 증가, correct_count는 오답이므로 0
       expect(mockManager.query).toHaveBeenCalledWith(
         expect.stringContaining('solved_count = solved_count + 1'),
-        expect.arrayContaining([0]), // isCorrect ? 1 : 0 → 오답이므로 0
+        [expect.any(Number), expect.any(Number), 0],
       );
     });
 

--- a/packages/backend/test/single-play.service.spec.ts
+++ b/packages/backend/test/single-play.service.spec.ts
@@ -239,6 +239,58 @@ describe('SinglePlayService', () => {
         expect.anything(),
         expect.objectContaining({ where: { id: matchId } }),
       );
+
+      // solved_count, correct_count 업데이트 검증 (정답이므로 correct_count + 1)
+      expect(mockManager.query).toHaveBeenCalledWith(
+        expect.stringContaining('solved_count = solved_count + 1'),
+        expect.arrayContaining([1]), // isCorrect ? 1 : 0 → 정답이므로 1
+      );
+    });
+
+    it('오답 제출 시 correct_count는 증가하지 않아야 함', async () => {
+      const userId = '1';
+      const questionId = 1;
+      const answer = 'Wrong Answer';
+      const mockQuestion = {
+        id: 1,
+        questionType: 'short',
+        content: 'What is React?',
+        difficulty: 1,
+        correctAnswer: 'React',
+      } as QuestionEntity;
+
+      const mockGradeResult = [
+        {
+          playerId: 'single-player',
+          answer: 'Wrong Answer',
+          isCorrect: false,
+          score: 0,
+          feedback: 'Incorrect',
+        },
+      ];
+
+      mockQuestionRepository.findOne.mockResolvedValue(mockQuestion);
+      mockQuizService.gradeQuestion.mockResolvedValue(mockGradeResult);
+      mockQuizService.determineAnswerStatus.mockReturnValue('incorrect');
+
+      const matchId = 123;
+      const mockManager = { save: jest.fn(), query: jest.fn(), findOne: jest.fn() };
+
+      mockDataSource.transaction.mockImplementation(async (cb: any) => cb(mockManager));
+
+      mockManager.findOne.mockResolvedValue({ id: matchId, player1Id: 1, matchType: 'single' });
+      mockManager.save.mockResolvedValue({});
+      mockManager.query.mockResolvedValue([[{ exp_point: 0 }], 1]);
+
+      const result = await service.submitAnswer(userId, matchId, questionId, answer);
+
+      expect(result.grade.isCorrect).toBe(false);
+
+      // solved_count는 항상 증가, correct_count는 오답이므로 0
+      expect(mockManager.query).toHaveBeenCalledWith(
+        expect.stringContaining('solved_count = solved_count + 1'),
+        expect.arrayContaining([0]), // isCorrect ? 1 : 0 → 오답이므로 0
+      );
     });
 
     it('존재하지 않는 문제 ID면 NotFoundException을 던져야 함', async () => {


### PR DESCRIPTION
## 📝 개요 (Description)

리더보드 API의 성능을 개선하기 위한 쿼리 최적화 리팩토링입니다.

### 내 순위 조회 최적화
- RANK() 윈도우 함수 → COUNT(*)+1 방식으로 변경
- 전체 정렬 없이 나보다 위인 유저 수만 집계

### Top 100 조회 최적화
- 싱글플레이: `user_statistics`에 `solved_count`, `correct_count` 비정규화 컬럼 추가
- 매 조회마다 `user_problem_banks` 서브쿼리 집계 제거

## 🔗 관련 이슈 (Related Issues)

- Closes #244
- Closes #245

## 🏷️ 작업 유형 (Type of Change)

- [ ] ✨ 기능 추가 (New Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] 🔧 설정 변경 및 기타 (Config & Other)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 컴파일/빌드 되나요?
- [x] 기존 테스트를 통과했나요? (새로운 테스트가 필요하다면 추가했나요?)
- [x] 스스로 코드를 리뷰했나요? (Self-review)
- [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
- [ ] 문서(README 등)에 변경 사항을 업데이트했나요?

## 📊 성능 테스트 결과

10만 유저, 100만 문제풀이 기록 환경에서 `EXPLAIN (ANALYZE, BUFFERS)`로 측정

### 내 순위 조회

| 방식 | DB 실행 시간 | e2e 응답 시간 | 비고 |
|------|-------------|--------------|------|
| RANK() (기존) | 107ms | 189ms | 전체 정렬 + 99,999행 버림 |
| **COUNT (변경)** | **12.9ms** | **13ms** | 정렬 없이 조건 필터링만 |

### Top 100 조회

| 모드 | 최적화 전 | 비정규화 적용 | Expression Index 적용 |
|------|----------|--------------|----------------------|
| 멀티플레이 | 42ms | - | **0.78ms** |
| 싱글플레이 | 603ms | 37ms | **0.69ms** |

> Expression Index는 DB에 직접 생성 필요 (마이그레이션 시스템 미적용)

## 🎸 기타 (Etc)

- 성능 측정 상세 분석은 Wiki 문서로 별도 정리 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 싱글플레이에서 풀이한 문제 수와 정답 수를 별도 통계로 기록

* **개선 사항**
  * 리더보드의 순위 산정 로직 개선으로 동률 처리와 순위 정확도 향상
  * 내 순위 조회가 정확한 순위를 반영하도록 개선

* **테스트**
  * 통계 증가 및 순위 조회 로직을 검증하는 테스트 추가/보완
<!-- end of auto-generated comment: release notes by coderabbit.ai -->