### PR TITLE
[PERF] 리더보드 성능 병목 해결

### DIFF
--- a/packages/backend/src/leaderboard/leaderboard.module.ts
+++ b/packages/backend/src/leaderboard/leaderboard.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { LeaderboardController } from './leaderboard.controller';
 import { LeaderboardService } from './leaderboard.service';
+import { RankRefreshService } from './rank-refresh.service';
 import { UserStatistics } from '../user/entity/user-statistics.entity';
 import { UserProblemBank } from '../problem-bank/entity/user-problem-bank.entity';
 import { Tier } from '../tier/entity/tier.entity';
@@ -9,6 +10,6 @@ import { Tier } from '../tier/entity/tier.entity';
 @Module({
   imports: [TypeOrmModule.forFeature([UserStatistics, UserProblemBank, Tier])],
   controllers: [LeaderboardController],
-  providers: [LeaderboardService],
+  providers: [LeaderboardService, RankRefreshService],
 })
 export class LeaderboardModule {}

--- a/packages/backend/src/leaderboard/leaderboard.service.ts
+++ b/packages/backend/src/leaderboard/leaderboard.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Brackets, Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { UserStatistics } from '../user/entity/user-statistics.entity';
 import { Tier } from '../tier/entity/tier.entity';
 import { MatchType } from './dto/leaderboard-query.dto';
@@ -38,6 +38,7 @@ export class LeaderboardService {
   constructor(
     @InjectRepository(UserStatistics)
     private readonly userStatisticsRepository: Repository<UserStatistics>,
+    private readonly dataSource: DataSource,
   ) {}
 
   async getLeaderboard(
@@ -147,32 +148,13 @@ export class LeaderboardService {
     const tierPoint = Number(myStats.tierPoint);
     const winCount = Number(myStats.winCount);
     const loseCount = Number(myStats.loseCount);
-    const totalGames = winCount + loseCount;
 
-    const winRateExpr =
-      'CASE WHEN us.winCount + us.loseCount > 0 THEN us.winCount * 1.0 / (us.winCount + us.loseCount) ELSE 0 END';
-    const myWinRateExpr = totalGames > 0 ? ':winCount * 1.0 / :totalGames' : '0';
+    const rankRow = await this.dataSource.query<{ rank: number }[]>(
+      'SELECT rank FROM mv_multi_rank WHERE user_id = $1',
+      [userId],
+    );
 
-    const result = await this.userStatisticsRepository
-      .createQueryBuilder('us')
-      .select('COUNT(*) + 1', 'rank')
-      .where('us.tierPoint > :tierPoint')
-      .orWhere(
-        new Brackets((qb) => {
-          qb.where('us.tierPoint = :tierPoint').andWhere(`${winRateExpr} > ${myWinRateExpr}`);
-        }),
-      )
-      .orWhere(
-        new Brackets((qb) => {
-          qb.where('us.tierPoint = :tierPoint')
-            .andWhere(`${winRateExpr} = ${myWinRateExpr}`)
-            .andWhere('us.winCount + us.loseCount > :totalGames');
-        }),
-      )
-      .setParameters({ tierPoint, winCount, totalGames })
-      .getRawOne<{ rank: string }>();
-
-    const rank = result ? Number(result.rank) : 0;
+    const rank = rankRow[0]?.rank ?? 0;
 
     return {
       rank,
@@ -264,30 +246,12 @@ export class LeaderboardService {
     const solvedCount = Number(myStats.solvedCount);
     const correctCount = Number(myStats.correctCount);
 
-    const correctRateExpr =
-      'CASE WHEN us.solvedCount > 0 THEN us.correctCount * 1.0 / us.solvedCount ELSE 0 END';
-    const myCorrectRateExpr = solvedCount > 0 ? ':correctCount * 1.0 / :solvedCount' : '0';
+    const rankRow = await this.dataSource.query<{ rank: number }[]>(
+      'SELECT rank FROM mv_single_rank WHERE user_id = $1',
+      [userId],
+    );
 
-    const result = await this.userStatisticsRepository
-      .createQueryBuilder('us')
-      .select('COUNT(*) + 1', 'rank')
-      .where('us.expPoint > :expPoint')
-      .orWhere(
-        new Brackets((qb) => {
-          qb.where('us.expPoint = :expPoint').andWhere(`${correctRateExpr} > ${myCorrectRateExpr}`);
-        }),
-      )
-      .orWhere(
-        new Brackets((qb) => {
-          qb.where('us.expPoint = :expPoint')
-            .andWhere(`${correctRateExpr} = ${myCorrectRateExpr}`)
-            .andWhere('us.solvedCount > :solvedCount');
-        }),
-      )
-      .setParameters({ expPoint, correctCount, solvedCount })
-      .getRawOne<{ rank: string }>();
-
-    const rank = result ? Number(result.rank) : 0;
+    const rank = rankRow[0]?.rank ?? 0;
 
     return {
       rank,

--- a/packages/backend/src/leaderboard/leaderboard.service.ts
+++ b/packages/backend/src/leaderboard/leaderboard.service.ts
@@ -154,7 +154,8 @@ export class LeaderboardService {
       [userId],
     );
 
-    const rank = rankRow[0]?.rank ?? 0;
+    const rank =
+      rankRow[0]?.rank ?? (await this.getMultiRankFallback(tierPoint, winCount, loseCount));
 
     return {
       rank,
@@ -165,6 +166,33 @@ export class LeaderboardService {
       loseCount,
       tier: myStats.tier,
     };
+  }
+
+  private async getMultiRankFallback(
+    tierPoint: number,
+    winCount: number,
+    loseCount: number,
+  ): Promise<number> {
+    const total = winCount + loseCount;
+    const winRate = total > 0 ? winCount / total : 0;
+
+    const result = await this.dataSource.query<{ rank: string }[]>(
+      `SELECT COUNT(*) + 1 AS rank
+       FROM user_statistics
+       WHERE tier_point > $1
+          OR (tier_point = $1
+              AND CASE WHEN win_count + lose_count > 0
+                       THEN win_count * 1.0 / (win_count + lose_count)
+                       ELSE 0 END > $2)
+          OR (tier_point = $1
+              AND CASE WHEN win_count + lose_count > 0
+                       THEN win_count * 1.0 / (win_count + lose_count)
+                       ELSE 0 END = $2
+              AND win_count + lose_count > $3)`,
+      [tierPoint, winRate, total],
+    );
+
+    return Number(result[0]?.rank ?? 1);
   }
 
   private async getSingleLeaderboard(userId: number): Promise<SingleLeaderboardResponseDto> {
@@ -251,7 +279,8 @@ export class LeaderboardService {
       [userId],
     );
 
-    const rank = rankRow[0]?.rank ?? 0;
+    const rank =
+      rankRow[0]?.rank ?? (await this.getSingleRankFallback(expPoint, solvedCount, correctCount));
 
     return {
       rank,
@@ -262,5 +291,31 @@ export class LeaderboardService {
       solvedCount,
       correctCount,
     };
+  }
+
+  private async getSingleRankFallback(
+    expPoint: number,
+    solvedCount: number,
+    correctCount: number,
+  ): Promise<number> {
+    const correctRate = solvedCount > 0 ? correctCount / solvedCount : 0;
+
+    const result = await this.dataSource.query<{ rank: string }[]>(
+      `SELECT COUNT(*) + 1 AS rank
+       FROM user_statistics
+       WHERE exp_point > $1
+          OR (exp_point = $1
+              AND CASE WHEN solved_count > 0
+                       THEN correct_count * 1.0 / solved_count
+                       ELSE 0 END > $2)
+          OR (exp_point = $1
+              AND CASE WHEN solved_count > 0
+                       THEN correct_count * 1.0 / solved_count
+                       ELSE 0 END = $2
+              AND solved_count > $3)`,
+      [expPoint, correctRate, solvedCount],
+    );
+
+    return Number(result[0]?.rank ?? 1);
   }
 }

--- a/packages/backend/src/leaderboard/rank-refresh.service.ts
+++ b/packages/backend/src/leaderboard/rank-refresh.service.ts
@@ -1,0 +1,123 @@
+import { Injectable, Logger, OnApplicationBootstrap, OnModuleDestroy } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+
+@Injectable()
+export class RankRefreshService implements OnApplicationBootstrap, OnModuleDestroy {
+  private readonly logger = new Logger(RankRefreshService.name);
+  private readonly REFRESH_INTERVAL_MS = 60000;
+  private intervalId: NodeJS.Timeout | null = null;
+  private isRefreshing = false;
+
+  constructor(private readonly dataSource: DataSource) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    await this.createExpressionIndexes();
+    await this.createViewsIfNotExist();
+    await this.refresh();
+    this.intervalId = setInterval(() => {
+      void this.refresh();
+    }, this.REFRESH_INTERVAL_MS);
+  }
+
+  onModuleDestroy(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  private async createExpressionIndexes(): Promise<void> {
+    await this.dataSource.query(`
+      CREATE INDEX IF NOT EXISTS idx_multi_ranking ON user_statistics (
+        tier_point DESC,
+        (CASE WHEN win_count + lose_count > 0
+              THEN win_count * 1.0 / (win_count + lose_count)
+              ELSE 0 END) DESC,
+        (win_count + lose_count) DESC
+      )
+    `);
+
+    await this.dataSource.query(`
+      CREATE INDEX IF NOT EXISTS idx_single_ranking ON user_statistics (
+        exp_point DESC,
+        (CASE WHEN solved_count > 0
+              THEN correct_count * 1.0 / solved_count
+              ELSE 0 END) DESC,
+        solved_count DESC
+      )
+    `);
+
+    await this.dataSource.query(`
+      CREATE INDEX IF NOT EXISTS idx_user_stats_tier_point
+        ON user_statistics (tier_point DESC)
+    `);
+
+    await this.dataSource.query(`
+      CREATE INDEX IF NOT EXISTS idx_user_stats_exp_point
+        ON user_statistics (exp_point DESC)
+    `);
+
+    this.logger.log('Leaderboard expression indexes ensured');
+  }
+
+  private async createViewsIfNotExist(): Promise<void> {
+    await this.dataSource.query(`
+      CREATE MATERIALIZED VIEW IF NOT EXISTS mv_multi_rank AS
+      SELECT
+        user_id,
+        CAST(RANK() OVER (
+          ORDER BY
+            tier_point DESC,
+            CASE WHEN win_count + lose_count > 0
+                 THEN win_count * 1.0 / (win_count + lose_count)
+                 ELSE 0 END DESC,
+            (win_count + lose_count) DESC
+        ) AS INTEGER) AS rank
+      FROM user_statistics
+    `);
+
+    await this.dataSource.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_multi_rank_user
+        ON mv_multi_rank (user_id)
+    `);
+
+    await this.dataSource.query(`
+      CREATE MATERIALIZED VIEW IF NOT EXISTS mv_single_rank AS
+      SELECT
+        user_id,
+        CAST(RANK() OVER (
+          ORDER BY
+            exp_point DESC,
+            CASE WHEN solved_count > 0
+                 THEN correct_count * 1.0 / solved_count
+                 ELSE 0 END DESC,
+            solved_count DESC
+        ) AS INTEGER) AS rank
+      FROM user_statistics
+    `);
+
+    await this.dataSource.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_single_rank_user
+        ON mv_single_rank (user_id)
+    `);
+
+    this.logger.log('Rank materialized views initialized');
+  }
+
+  private async refresh(): Promise<void> {
+    if (this.isRefreshing) {
+      return;
+    }
+
+    this.isRefreshing = true;
+
+    try {
+      await this.dataSource.query('REFRESH MATERIALIZED VIEW CONCURRENTLY mv_multi_rank');
+      await this.dataSource.query('REFRESH MATERIALIZED VIEW CONCURRENTLY mv_single_rank');
+    } catch (error) {
+      this.logger.error(`Rank view refresh failed: ${(error as Error).message}`);
+    } finally {
+      this.isRefreshing = false;
+    }
+  }
+}

--- a/packages/backend/src/leaderboard/rank-refresh.service.ts
+++ b/packages/backend/src/leaderboard/rank-refresh.service.ts
@@ -5,6 +5,7 @@ import { DataSource } from 'typeorm';
 export class RankRefreshService implements OnApplicationBootstrap, OnModuleDestroy {
   private readonly logger = new Logger(RankRefreshService.name);
   private readonly REFRESH_INTERVAL_MS = 60000;
+  private readonly ADVISORY_LOCK_KEY = 7233597;
   private intervalId: NodeJS.Timeout | null = null;
   private isRefreshing = false;
 
@@ -28,7 +29,7 @@ export class RankRefreshService implements OnApplicationBootstrap, OnModuleDestr
 
   private async createExpressionIndexes(): Promise<void> {
     await this.dataSource.query(`
-      CREATE INDEX IF NOT EXISTS idx_multi_ranking ON user_statistics (
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_multi_ranking ON user_statistics (
         tier_point DESC,
         (CASE WHEN win_count + lose_count > 0
               THEN win_count * 1.0 / (win_count + lose_count)
@@ -38,7 +39,7 @@ export class RankRefreshService implements OnApplicationBootstrap, OnModuleDestr
     `);
 
     await this.dataSource.query(`
-      CREATE INDEX IF NOT EXISTS idx_single_ranking ON user_statistics (
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_single_ranking ON user_statistics (
         exp_point DESC,
         (CASE WHEN solved_count > 0
               THEN correct_count * 1.0 / solved_count
@@ -48,12 +49,12 @@ export class RankRefreshService implements OnApplicationBootstrap, OnModuleDestr
     `);
 
     await this.dataSource.query(`
-      CREATE INDEX IF NOT EXISTS idx_user_stats_tier_point
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_stats_tier_point
         ON user_statistics (tier_point DESC)
     `);
 
     await this.dataSource.query(`
-      CREATE INDEX IF NOT EXISTS idx_user_stats_exp_point
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_stats_exp_point
         ON user_statistics (exp_point DESC)
     `);
 
@@ -109,6 +110,15 @@ export class RankRefreshService implements OnApplicationBootstrap, OnModuleDestr
       return;
     }
 
+    const lockResult = await this.dataSource.query<{ acquired: boolean }[]>(
+      'SELECT pg_try_advisory_lock($1) AS acquired',
+      [this.ADVISORY_LOCK_KEY],
+    );
+
+    if (!lockResult[0]?.acquired) {
+      return;
+    }
+
     this.isRefreshing = true;
 
     try {
@@ -118,6 +128,7 @@ export class RankRefreshService implements OnApplicationBootstrap, OnModuleDestr
       this.logger.error(`Rank view refresh failed: ${(error as Error).message}`);
     } finally {
       this.isRefreshing = false;
+      await this.dataSource.query('SELECT pg_advisory_unlock($1)', [this.ADVISORY_LOCK_KEY]);
     }
   }
 }

--- a/packages/backend/src/leaderboard/rank-refresh.service.ts
+++ b/packages/backend/src/leaderboard/rank-refresh.service.ts
@@ -5,7 +5,6 @@ import { DataSource } from 'typeorm';
 export class RankRefreshService implements OnApplicationBootstrap, OnModuleDestroy {
   private readonly logger = new Logger(RankRefreshService.name);
   private readonly REFRESH_INTERVAL_MS = 60000;
-  private readonly ADVISORY_LOCK_KEY = 7233597;
   private intervalId: NodeJS.Timeout | null = null;
   private isRefreshing = false;
 
@@ -111,8 +110,7 @@ export class RankRefreshService implements OnApplicationBootstrap, OnModuleDestr
     }
 
     const lockResult = await this.dataSource.query<{ acquired: boolean }[]>(
-      'SELECT pg_try_advisory_lock($1) AS acquired',
-      [this.ADVISORY_LOCK_KEY],
+      `SELECT pg_try_advisory_lock(hashtext('rank_refresh')) AS acquired`,
     );
 
     if (!lockResult[0]?.acquired) {
@@ -128,7 +126,7 @@ export class RankRefreshService implements OnApplicationBootstrap, OnModuleDestr
       this.logger.error(`Rank view refresh failed: ${(error as Error).message}`);
     } finally {
       this.isRefreshing = false;
-      await this.dataSource.query('SELECT pg_advisory_unlock($1)', [this.ADVISORY_LOCK_KEY]);
+      await this.dataSource.query(`SELECT pg_advisory_unlock(hashtext('rank_refresh'))`);
     }
   }
 }

--- a/packages/backend/src/leaderboard/rank-refresh.service.ts
+++ b/packages/backend/src/leaderboard/rank-refresh.service.ts
@@ -109,24 +109,34 @@ export class RankRefreshService implements OnApplicationBootstrap, OnModuleDestr
       return;
     }
 
-    const lockResult = await this.dataSource.query<{ acquired: boolean }[]>(
-      `SELECT pg_try_advisory_lock(hashtext('rank_refresh')) AS acquired`,
-    );
-
-    if (!lockResult[0]?.acquired) {
-      return;
-    }
-
-    this.isRefreshing = true;
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    let lockAcquired = false;
 
     try {
-      await this.dataSource.query('REFRESH MATERIALIZED VIEW CONCURRENTLY mv_multi_rank');
-      await this.dataSource.query('REFRESH MATERIALIZED VIEW CONCURRENTLY mv_single_rank');
+      const lockResult = (await queryRunner.query(
+        `SELECT pg_try_advisory_lock(hashtext('rank_refresh')) AS acquired`,
+      )) as { acquired: boolean }[];
+      lockAcquired = !!lockResult[0]?.acquired;
+
+      if (!lockAcquired) {
+        return;
+      }
+
+      this.isRefreshing = true;
+
+      await queryRunner.query('REFRESH MATERIALIZED VIEW CONCURRENTLY mv_multi_rank');
+      await queryRunner.query('REFRESH MATERIALIZED VIEW CONCURRENTLY mv_single_rank');
     } catch (error) {
       this.logger.error(`Rank view refresh failed: ${(error as Error).message}`);
     } finally {
       this.isRefreshing = false;
-      await this.dataSource.query(`SELECT pg_advisory_unlock(hashtext('rank_refresh'))`);
+
+      if (lockAcquired) {
+        await queryRunner.query(`SELECT pg_advisory_unlock(hashtext('rank_refresh'))`);
+      }
+
+      await queryRunner.release();
     }
   }
 }

--- a/packages/backend/test/leaderboard/leaderboard.service.spec.ts
+++ b/packages/backend/test/leaderboard/leaderboard.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { NotFoundException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
 import { LeaderboardService } from '../../src/leaderboard/leaderboard.service';
 import { UserStatistics } from '../../src/user/entity/user-statistics.entity';
 import { MatchType } from '../../src/leaderboard/dto/leaderboard-query.dto';
@@ -12,6 +13,7 @@ import {
 describe('LeaderboardService', () => {
   let service: LeaderboardService;
   let mockUserStatisticsRepository: any;
+  let mockDataSource: any;
 
   const createMockQueryBuilder = (overrides = {}) => ({
     innerJoin: jest.fn().mockReturnThis(),
@@ -36,6 +38,9 @@ describe('LeaderboardService', () => {
   beforeEach(async () => {
     mockUserStatisticsRepository = {
       createQueryBuilder: jest.fn(),
+    };
+
+    mockDataSource = {
       query: jest.fn(),
     };
 
@@ -45,6 +50,10 @@ describe('LeaderboardService', () => {
         {
           provide: getRepositoryToken(UserStatistics),
           useValue: mockUserStatisticsRepository,
+        },
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
         },
       ],
     }).compile();
@@ -64,14 +73,12 @@ describe('LeaderboardService', () => {
       const myStatsQB = createMockQueryBuilder({
         getRawOne: jest.fn().mockResolvedValue(myStats),
       });
-      const rankQB = createMockQueryBuilder({
-        getRawOne: jest.fn().mockResolvedValue({ rank: String(myRank) }),
-      });
 
       mockUserStatisticsRepository.createQueryBuilder
         .mockReturnValueOnce(rankingsQB)
-        .mockReturnValueOnce(myStatsQB)
-        .mockReturnValueOnce(rankQB);
+        .mockReturnValueOnce(myStatsQB);
+
+      mockDataSource.query.mockResolvedValue([{ rank: myRank }]);
     };
 
     it('랭킹 목록과 내 순위를 반환한다', async () => {
@@ -302,14 +309,12 @@ describe('LeaderboardService', () => {
       const myStatsQB = createMockQueryBuilder({
         getRawOne: jest.fn().mockResolvedValue(myStats),
       });
-      const rankQB = createMockQueryBuilder({
-        getRawOne: jest.fn().mockResolvedValue({ rank: String(myRank) }),
-      });
 
       mockUserStatisticsRepository.createQueryBuilder
         .mockReturnValueOnce(rankingsQB)
-        .mockReturnValueOnce(myStatsQB)
-        .mockReturnValueOnce(rankQB);
+        .mockReturnValueOnce(myStatsQB);
+
+      mockDataSource.query.mockResolvedValue([{ rank: myRank }]);
     };
 
     it('랭킹 목록과 내 순위를 반환한다', async () => {
@@ -530,14 +535,12 @@ describe('LeaderboardService', () => {
           tier: 'silver',
         }),
       });
-      const rankQB = createMockQueryBuilder({
-        getRawOne: jest.fn().mockResolvedValue({ rank: '1' }),
-      });
 
       mockUserStatisticsRepository.createQueryBuilder
         .mockReturnValueOnce(rankingsQB)
-        .mockReturnValueOnce(myStatsQB)
-        .mockReturnValueOnce(rankQB);
+        .mockReturnValueOnce(myStatsQB);
+
+      mockDataSource.query.mockResolvedValue([{ rank: 1 }]);
 
       const result = (await service.getLeaderboard(
         MatchType.MULTI,
@@ -598,14 +601,12 @@ describe('LeaderboardService', () => {
       const myStatsQB = createMockQueryBuilder({
         getRawOne: jest.fn().mockResolvedValue(myStats),
       });
-      const rankQB = createMockQueryBuilder({
-        getRawOne: jest.fn().mockResolvedValue({ rank: '4' }),
-      });
 
       mockUserStatisticsRepository.createQueryBuilder
         .mockReturnValueOnce(rankingsQB)
-        .mockReturnValueOnce(myStatsQB)
-        .mockReturnValueOnce(rankQB);
+        .mockReturnValueOnce(myStatsQB);
+
+      mockDataSource.query.mockResolvedValue([{ rank: 4 }]);
 
       const result = (await service.getLeaderboard(
         MatchType.MULTI,


### PR DESCRIPTION
## 핵심 변경 사항

리더보드 MY RANK 쿼리의 성능 병목을 Materialized View로 해결하고, 변경된 의존성에 맞게 테스트 코드를 수정했습니다.

## 작업 내용

- `COUNT(*)+1` 서브쿼리 방식의 MY RANK 조회를 Materialized View(`mv_multi_rank`, `mv_single_rank`) Index Scan으로 교체 (단건 12ms → 0.05ms)
- `RankRefreshService` 추가: 앱 부트스트랩 시 Expression Index 및 Materialized View 자동 생성, 60초 주기 비동기 갱신
- TypeORM `synchronize: true`로 인한 인덱스 소실 문제 해결: 재시작마다 `CREATE INDEX CONCURRENTLY IF NOT EXISTS`로 재생성
- `LeaderboardService`에 `DataSource` 주입 추가, `LeaderboardModule`에 `RankRefreshService` 등록
- 테스트 코드에 `DataSource` mock 주입 및 rank 쿼리 mock 방식 수정
- MV miss 시 live fallback 추가: MV에 row가 없는 신규 유저의 경우 `COUNT(*)+1` 쿼리로 대체
- 다중 replica 환경에서 MV 갱신 중복 실행 방지: `pg_try_advisory_lock` 기반 직렬화 적용

## 테스트 결과

| 지표 | 개선 전 | 개선 후 |
|---|---|---|
| p(95) 응답시간 | 543ms | 168ms |
| RPS | 155 | 344 |
| 총 이터레이션 (2분) | 8,571 | 20,751 |

- k6 부하 테스트: 100k 유저, 50 VU, 멀티/싱글 리더보드 반복 호출
- 유닛 테스트: 14개 전부 통과

## 리뷰 포인트

- `REFRESH_INTERVAL_MS = 60000` 값 조정 여부: 60초 staleness가 서비스 요구사항에 적합한지 확인
- `REFRESH MATERIALIZED VIEW CONCURRENTLY` 실행 비용(~1,139ms/회)이 트래픽 증가 시 DB에 미치는 영향
- rankings(live)와 myRanking.rank(MV, 최대 60초 stale)는 동일 스냅샷이 아님 — 설계상 허용된 trade-off이나 인지 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 백그라운드에서 물리화된 순위 뷰를 생성·주기적으로 갱신하는 자동 순위 갱신 서비스가 추가되었습니다.

* **성능 개선**
  * 순위 조회가 미리 계산된 뷰에서 우선 조회되도록 변경되어 응답 속도가 향상되었습니다.

* **안정성 / 버그 개선**
  * 뷰 조회 실패 시 안전하게 순위를 재계산하는 폴백 로직이 추가되어 빈 결과 처리 개선.

* **테스트**
  * 순위 조회 변경사항을 반영하도록 단위 테스트가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->