### PR TITLE
[PERF] 매치 히스토리 조회 성능 개선 — 인덱스 도입 및 쿼리 분리

### DIFF
--- a/packages/backend/src/match/entity/match.entity.ts
+++ b/packages/backend/src/match/entity/match.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   OneToMany,
@@ -12,6 +13,8 @@ import { Round } from './round.entity';
 import { UserProblemBank } from '../../problem-bank/entity';
 
 @Entity('matches')
+@Index('idx_matches_player1', ['player1Id', 'createdAt'])
+@Index('idx_matches_player2', ['player2Id', 'createdAt'])
 export class Match {
   @PrimaryGeneratedColumn('increment', { type: 'bigint' })
   id: number;

--- a/packages/backend/src/match/entity/round-answer.entity.ts
+++ b/packages/backend/src/match/entity/round-answer.entity.ts
@@ -1,8 +1,10 @@
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
-import { User } from '../../user/entity/user.entity';
+import { Column, Entity, Index, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { User } from '../../user/entity';
 import { Round } from './round.entity';
 
 @Entity('round_answers')
+@Index('idx_round_answers_round', ['roundId'])
+@Index('idx_round_answers_user', ['userId'])
 export class RoundAnswer {
   @PrimaryGeneratedColumn('increment', { type: 'bigint' })
   id: number;

--- a/packages/backend/src/match/entity/round.entity.ts
+++ b/packages/backend/src/match/entity/round.entity.ts
@@ -1,9 +1,18 @@
-import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { Match } from './match.entity';
-import { Question } from '../../quiz/entity/question.entity';
+import { Question } from '../../quiz/entity';
 import { RoundAnswer } from './round-answer.entity';
 
 @Entity('rounds')
+@Index('idx_rounds_match', ['matchId'])
 export class Round {
   @PrimaryGeneratedColumn('increment', { type: 'bigint' })
   id: number;

--- a/packages/backend/src/problem-bank/entity/user-problem-bank.entity.ts
+++ b/packages/backend/src/problem-bank/entity/user-problem-bank.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -12,6 +13,7 @@ import { Question } from '../../quiz/entity';
 import { Match } from '../../match/entity';
 
 @Entity('user_problem_banks')
+@Index('idx_user_problem_banks_match', ['matchId'])
 export class UserProblemBank {
   @PrimaryGeneratedColumn('increment', { type: 'bigint' })
   id: number;

--- a/packages/backend/src/user/user.service.ts
+++ b/packages/backend/src/user/user.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { User, UserStatistics } from './entity';
 import { UserProblemBank } from '../problem-bank/entity';
 import { UserTierHistory } from '../tier/entity';
@@ -78,8 +78,25 @@ export class UserService {
   }
 
   async getMatchHistory(userId: number): Promise<MatchHistoryResponseDto> {
+    // 매치 ID만 조회 (JOIN 없이, DISTINCT 없이)
+    const matchIdRows = await this.matchRepository
+      .createQueryBuilder('match')
+      .select('match.id')
+      .where('match.player1Id = :userId OR match.player2Id = :userId', { userId })
+      .orderBy('match.createdAt', 'DESC')
+      .limit(10)
+      .getRawMany();
+
+    const matchIds = matchIdRows.map((r: unknown) => (r as { match_id: number }).match_id);
+
+    if (matchIds.length === 0) {
+      return { matchHistory: [] };
+    }
+
+    // Steprounds 체인 로딩 (problemBanks 없음 → 카테시안 곱 방지)
+    // take 없음 → TypeORM DISTINCT 서브쿼리 미생성
     const matches = await this.matchRepository.find({
-      where: [{ player1Id: userId }, { player2Id: userId }],
+      where: { id: In(matchIds) },
       relations: [
         'player1',
         'player2',
@@ -89,15 +106,40 @@ export class UserService {
         'rounds.question.categoryQuestions',
         'rounds.question.categoryQuestions.category',
         'rounds.question.categoryQuestions.category.parent',
-        'problemBanks',
-        'problemBanks.question',
-        'problemBanks.question.categoryQuestions',
-        'problemBanks.question.categoryQuestions.category',
-        'problemBanks.question.categoryQuestions.category.parent',
       ],
       order: { createdAt: 'DESC' },
-      take: 10,
     });
+
+    // problemBanks 별도 로딩 (single 매치의 카테고리 fallback용)
+    const singleMatchIds = matches.filter((m) => m.matchType === 'single').map((m) => Number(m.id));
+
+    if (singleMatchIds.length > 0) {
+      const problemBanks = await this.userProblemBankRepository.find({
+        where: { matchId: In(singleMatchIds) },
+        relations: [
+          'question',
+          'question.categoryQuestions',
+          'question.categoryQuestions.category',
+          'question.categoryQuestions.category.parent',
+        ],
+      });
+
+      // 매치에 problemBanks 수동 매핑
+      const pbByMatchId = new Map<number, UserProblemBank[]>();
+
+      for (const pb of problemBanks) {
+        const mid = Number(pb.matchId);
+        const list = pbByMatchId.get(mid) ?? [];
+        list.push(pb);
+        pbByMatchId.set(mid, list);
+      }
+
+      for (const match of matches) {
+        if (match.matchType === 'single') {
+          match.problemBanks = pbByMatchId.get(Number(match.id)) ?? [];
+        }
+      }
+    }
 
     const matchHistory = await Promise.all(
       matches.map((match) =>

--- a/packages/backend/test/user/user.service.spec.ts
+++ b/packages/backend/test/user/user.service.spec.ts
@@ -16,6 +16,7 @@ describe('UserService', () => {
 
   const mockUserProblemBankRepository = {
     createQueryBuilder: jest.fn(),
+    find: jest.fn(),
   };
 
   const mockUserTierHistoryRepository = {
@@ -23,8 +24,17 @@ describe('UserService', () => {
     findOne: jest.fn(),
   };
 
+  const mockQueryBuilder = {
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn().mockResolvedValue([]),
+  };
+
   const mockMatchRepository = {
     find: jest.fn(),
+    createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
   };
 
   beforeEach(async () => {
@@ -316,6 +326,7 @@ describe('UserService', () => {
         tierChange: 25,
       };
 
+      mockQueryBuilder.getRawMany.mockResolvedValue([{ match_id: 1 }]);
       mockMatchRepository.find.mockResolvedValue(mockMatches);
       mockUserTierHistoryRepository.findOne.mockResolvedValue(mockTierHistory);
 
@@ -358,7 +369,9 @@ describe('UserService', () => {
         },
       ];
 
+      mockQueryBuilder.getRawMany.mockResolvedValue([{ match_id: 2 }]);
       mockMatchRepository.find.mockResolvedValue(mockMatches);
+      mockUserProblemBankRepository.find.mockResolvedValue([]);
 
       const result = await service.getMatchHistory(1);
 
@@ -386,6 +399,7 @@ describe('UserService', () => {
         },
       ];
 
+      mockQueryBuilder.getRawMany.mockResolvedValue([{ match_id: 3 }]);
       mockMatchRepository.find.mockResolvedValue(mockMatches);
       mockUserTierHistoryRepository.findOne.mockResolvedValue(null);
 


### PR DESCRIPTION
  ## 📝 개요 (Description)

  매치 히스토리 API의 두 가지 병목을 해결한다:

  1. **인덱스 부재**: matches, rounds, round_answers에 인덱스를 추가하여 Seq Scan을 제거
  2. **카테시안 곱**: TypeORM의 14개 relations 동시 JOIN을 3단계 분리 로딩으로 변경

  ### 인덱스 추가 (엔티티 @Index 데코레이터)

  | 엔티티 | 인덱스 | 용도 |
  |--------|--------|------|
  | `Match` | `idx_matches_player1(player1Id, createdAt)` | 유저의 매치 검색 + 정렬 |
  | `Match` | `idx_matches_player2(player2Id, createdAt)` | 유저의 매치 검색 + 정렬 |
  | `Round` | `idx_rounds_match(matchId)` | 매치-라운드 JOIN 최적화 |
  | `RoundAnswer` | `idx_round_answers_round(roundId)` | 라운드-답안 JOIN 최적화 |
  | `RoundAnswer` | `idx_round_answers_user(userId)` | 유저별 답안 조회 |

  ### 쿼리 3단계 분리 (카테시안 곱 제거)

  ```typescript
  // Before: 1개 쿼리, 14 JOIN → 카테시안 곱 (10건 → 976건)
  const matches = await this.matchRepository.find({
    relations: [...14개],
    take: 10,  // ← DISTINCT 서브쿼리 트리거
  });

  // After: 3단계 분리 → 카테시안 곱 없음
  // Step 1: 매치 ID만 조회 (getRawMany → DISTINCT 없음)
  const matchIdRows = await this.matchRepository
    .createQueryBuilder('match')
    .select('match.id')
    .where('match.player1Id = :userId OR match.player2Id = :userId', { userId })
    .orderBy('match.createdAt', 'DESC')
    .limit(10)
    .getRawMany();

  // Step 2: rounds 체인만 로딩 (take 없음 → DISTINCT 없음)
  const matches = await this.matchRepository.find({
    where: { id: In(matchIds) },
    relations: ['player1', 'player2', 'rounds', 'rounds.answers', ...8개],
  });

  // Step 3: problemBanks 별도 로딩 → 수동 매핑
  const problemBanks = await this.userProblemBankRepository.find({
    where: { matchId: In(singleMatchIds) },
    relations: ['question', ...category chain],
  });
```

## 🔗 관련 이슈 (Related Issues)

  - Closes #258 

## 🏷️ 작업 유형 (Type of Change)

  - ✨ 기능 추가 (New Feature)
  - 🐛 버그 수정 (Bug Fix)
  - ♻️ 리팩토링 (Refactoring)
  - 📝 문서 업데이트 (Documentation)
  - 🔧 설정 변경 및 기타 (Config & Other)


##  ✅ 체크리스트 (Checklist)

  - 코드가 정상적으로 컴파일/빌드 되나요?
  - 기존 테스트를 통과했나요? (새로운 테스트가 필요하다면 추가했나요?)
  - 스스로 코드를 리뷰했나요? (Self-review)
  - 불필요한 주석이나 디버깅 코드는 제거했나요?
  - 문서(README 등)에 변경 사항을 업데이트했나요?


  EXPLAIN ANALYZE 비교 — relations 로딩 쿼리

  Before (인덱스 없음)
  Execution Time: 450ms
  → Parallel Seq Scan on round_answers  (5,000,204 rows)  ← 500만건 풀스캔
  → Parallel Seq Scan on rounds         (2,500,101 rows)  ← 250만건 풀스캔
  → Parallel Seq Scan on matches        (500,020 rows)    ← 50만건 풀스캔
  Buffers: shared hit=9,017 read=90,997

  After (인덱스 적용)
  Execution Time: 133ms
  → Index Scan using idx_round_answers_round  (2건/라운드)
  → Index Scan using idx_rounds_match         (5건/매치)
  → Index Scan using PK on matches            (10건)
  Buffers: shared hit=4,936 read=13,061

  JOIN row 폭발 증거 (카테시안 곱)

  matches만                             →   10 rows
  + rounds                              →   50 rows  (×5)
  + round_answers                       →  100 rows  (×2)
  + problemBanks (카테시안 곱!)         →  280 rows  (×2.8)
  + category chains 양쪽 (Full 14 JOIN) →  976 rows  (×3.5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **성능 개선**
  * 경기·라운드·사용자 문제 은행 관련 DB 인덱스가 추가되어 경기 조회 성능이 향상되었습니다.
  * 경기 이력 조회 로직이 개선되어 최근 경기 로딩과 페이징 처리 속도가 빨라졌습니다
* **테스트**
  * 경기 이력 관련 단위 테스트와 목 설정이 보강되어 다양한 조회 시나리오 검증이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->