### PR TITLE
[PERF] 문제은행 user_id + answer_status 복합 인덱스 추가

### DIFF
--- a/packages/backend/src/problem-bank/entity/user-problem-bank.entity.ts
+++ b/packages/backend/src/problem-bank/entity/user-problem-bank.entity.ts
@@ -14,6 +14,7 @@ import { Match } from '../../match/entity';
 
 @Entity('user_problem_banks')
 @Index('idx_user_problem_banks_match', ['matchId'])
+@Index('idx_problem_bank_user_status', ['userId', 'answerStatus'])
 export class UserProblemBank {
   @PrimaryGeneratedColumn('increment', { type: 'bigint' })
   id: number;


### PR DESCRIPTION
  ## 📝 개요 (Description)

  문제은행 API에서 `user_problem_banks` 100만건을 매 요청마다 풀스캔하는 문제를 복합 인덱스로 해결한다.

  ### 병목 원인

  → Parallel Seq Scan on user_problem_banks (1,000,044 rows)
      Filter: (user_id = 1 AND answer_status = 'incorrect')
      Rows Removed by Filter: 340,330
      Execution Time: 62ms

  7건만 필요한데 100만건을 풀스캔하고 34만건을 읽고 버리는 비효율.

  ### 해결

  ```typescript
  // user-problem-bank.entity.ts
  @Entity('user_problem_banks')
  @Index('idx_problem_bank_user_status', ['userId', 'answerStatus'])
  export class UserProblemBank { ... }
```

  복합 인덱스 1개로 문제은행의 4종류 쿼리를 모두 커버:
  - WHERE user_id = $1 → 인덱스 prefix 활용
  - WHERE user_id = $1 AND answer_status = $2 → 완전 매칭
  - SELECT COUNT(*) WHERE user_id = $1 → prefix 활용
  - SELECT SUM(CASE ...) WHERE user_id = $1 → prefix 활용
 

### 🔗 관련 이슈 (Related Issues)

  - Closes #260

  🏷️작업 유형 (Type of Change)

  - ✨ 기능 추가 (New Feature)
  - 🐛 버그 수정 (Bug Fix)
  - ♻️ 리팩토링 (Refactoring)
  - 📝 문서 업데이트 (Documentation)
  - 🔧 설정 변경 및 기타 (Config & Other)

### ✅ 체크리스트 (Checklist)

  - 코드가 정상적으로 컴파일/빌드 되나요?
  - 기존 테스트를 통과했나요? (새로운 테스트가 필요하다면 추가했나요?)
  - 스스로 코드를 리뷰했나요? (Self-review)
  - 불필요한 주석이나 디버깅 코드는 제거했나요?
  - 문서(README 등)에 변경 사항을 업데이트했나요?


###  EXPLAIN ANALYZE 비교

  Before (인덱스 없음)
  Execution Time: 62ms
  → Parallel Seq Scan on user_problem_banks
      Filter: (user_id = 1 AND answer_status = 'incorrect')
      Rows Removed by Filter: 340,330
      Buffers: shared hit=15,303

  After (복합 인덱스 적용)
  Execution Time: 1.4ms
  → Index Scan using idx_problem_bank_user_status
      Index Cond: (user_id = 1 AND answer_status = 'incorrect')
      Index Searches: 1
      Buffers: shared hit=5 read=3

```
  부하테스트 비교 (50 VUs, 2분)

  ┌──────────────────┬──────────┬───────────┬──────┐
  │       지표       │  Before  │   After   │ 개선 │
  ├──────────────────┼──────────┼───────────┼──────┤
  │ problem_bank p95 │ 884ms    │ 194ms     │ 4.6x │
  ├──────────────────┼──────────┼───────────┼──────┤
  │ RPS              │ 63 req/s │ 270 req/s │ 4.3x │
  ├──────────────────┼──────────┼───────────┼──────┤
  │ 총 요청 수       │ 7,630    │ 32,638    │ 4.3x │
  └──────────────────┴──────────┴───────────┴──────┘
```

### 🎸 기타 (Etc)

  인덱스 컬럼 순서 선택 근거

  (user_id, answer_status) 순서를 선택한 이유:
  - user_id 단독 조회 쿼리(통계 집계, 필터 없는 목록)에서 prefix로 인덱스 활용 가능
  - (answer_status, user_id) 순서로 하면 answer_status 단독 조회가 없어 prefix 활용 불가

  쓰기 성능 영향

  INSERT 시 인덱스 1개 추가 갱신 → 0.1ms 미만 오버헤드. 문제은행 INSERT는 게임 종료 시 1회이므로 영향 없음.
 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데이터베이스 쿼리 성능을 개선하기 위해 데이터베이스 인덱스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->