### PR TITLE
[PERF] 리더보드/마이페이지 독립 쿼리 Promise.all 병렬 처리

### DIFF
--- a/packages/backend/src/leaderboard/leaderboard.service.ts
+++ b/packages/backend/src/leaderboard/leaderboard.service.ts
@@ -53,8 +53,10 @@ export class LeaderboardService {
   }
 
   private async getMultiLeaderboard(userId: number): Promise<MultiLeaderboardResponseDto> {
-    const rankings = await this.getMultiRankings();
-    const myRanking = await this.getMultiMyRanking(userId);
+    const [rankings, myRanking] = await Promise.all([
+      this.getMultiRankings(),
+      this.getMultiMyRanking(userId),
+    ]);
 
     return { rankings, myRanking };
   }
@@ -196,8 +198,10 @@ export class LeaderboardService {
   }
 
   private async getSingleLeaderboard(userId: number): Promise<SingleLeaderboardResponseDto> {
-    const rankings = await this.getSingleRankings();
-    const myRanking = await this.getSingleMyRanking(userId);
+    const [rankings, myRanking] = await Promise.all([
+      this.getSingleRankings(),
+      this.getSingleMyRanking(userId),
+    ]);
 
     return { rankings, myRanking };
   }

--- a/packages/backend/src/user/user.service.ts
+++ b/packages/backend/src/user/user.service.ts
@@ -32,10 +32,13 @@ export class UserService {
   ) {}
 
   async getMyPageData(userId: number): Promise<MyPageResponseDto> {
-    const user = await this.userRepository.findOne({
-      where: { id: userId },
-      relations: ['statistics'],
-    });
+    const [user, problemStats] = await Promise.all([
+      this.userRepository.findOne({
+        where: { id: userId },
+        relations: ['statistics'],
+      }),
+      this.buildProblemStats(userId),
+    ]);
 
     if (!user) {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
@@ -49,7 +52,6 @@ export class UserService {
     const rank = this.buildRank(tierPoint);
     const { level, needExpPoint, remainedExpPoint } = calcLevel(expPoint);
     const matchStats = this.buildMatchStats(stats);
-    const problemStats = await this.buildProblemStats(userId);
 
     return {
       profile,


### PR DESCRIPTION
- getMultiLeaderboard: rankings + myRanking 병렬 실행
- getSingleLeaderboard: rankings + myRanking 병렬 실행
- getMyPageData: user 조회 + problemStats 병렬 실행

## 📝 개요 (Description)

- 리더보드와 마이페이지 API에서 서로 의존성이 없는 DB 쿼리가 순차 실행되던 것을 `Promise.all`로 병렬 처리한다.

## 🔗 관련 이슈 (Related Issues)

-   Closes #266

## 🏷️ 작업 유형 (Type of Change)

<!-- 해당되는 항목에 체크(x) 해주세요 -->

-   [x] ✨ 기능 추가 (New Feature)
-   [ ] 🐛 버그 수정 (Bug Fix)
-   [ ] ♻️ 리팩토링 (Refactoring)
-   [ ] 📝 문서 업데이트 (Documentation)
-   [ ] 🔧 설정 변경 및 기타 (Config & Other)

## ✅ 체크리스트 (Checklist)

<!-- PR을 올리기 전, 다음 항목들을 확인해주세요 -->

-   [x] 코드가 정상적으로 컴파일/빌드 되나요?
-   [x] 기존 테스트를 통과했나요? (새로운 테스트가 필요하다면 추가했나요?)
-   [x] 스스로 코드를 리뷰했나요? (Self-review)
-   [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
-   [x] 문서(README 등)에 변경 사항을 업데이트했나요?

### 부하테스트 비교 (30 VUs, 1분)

| 지표 | Before (순차) | After (병렬) | 개선 |
|------|-------------|-------------|------|
| http_req_duration p95 | 3,690ms | **2,560ms** | **1.4x** |
| RPS | 22 req/s | **31 req/s** | **1.4x** |
| 총 요청 수 | 1,381 | **1,907** | 1.4x |

### 엔드포인트별 p95

| 엔드포인트 | Before | After | 개선 | 변경 내용 |
|-----------|--------|-------|------|----------|
| **리더보드** | 3,690ms (추정) | **1,670ms** | 병렬화 적용 | rankings + myRanking 동시 실행 |
| **프로필** | 2,200ms (추정) | **836ms** | 병렬화 적용 | user조회 + problemStats 동시 실행 |

## 🎸 기타 (Etc)

### 이 프로젝트에서 문제가 안 되는 이유

  - TypeORM 기본 커넥션 풀 10개 → 2개 동시 사용은 충분
  - 병렬화 쿼리 최대 2개 → 커넥션 경합 미미
  - getMyPageData에서 user 조회 실패 시 Promise.all이 즉시 reject → NotFoundException 정상 전파

### 교훈

  - 개별 요청 단축 효과는 미미 (134ms → 128ms, 6ms 절약)
  - 전체 처리량 개선이 핵심 (RPS 22 → 31, 40% 향상) — DB 커넥션 점유 시간 감소가 원인
  - 인덱스 > 쿼리 분리 > 병렬화 순서로 효과가 크다 (병렬화는 마지막 미세 조정)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 사용자 순위 조회 응답 속도가 개선되었습니다.
  * 사용자 페이지 데이터 로딩 성능이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->