### PR TITLE
[REFACTOR] HTTP 엔드포인트 Rate Limiting 적용

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,6 +26,7 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/platform-socket.io": "^10.4.20",
     "@nestjs/swagger": "^7.4.0",
+    "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.0",
     "@nestjs/websockets": "^10.4.20",
     "@sentry/nestjs": "^10.38.0",

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -1,5 +1,6 @@
 import { MiddlewareConsumer, Module, ModuleMetadata, NestModule } from '@nestjs/common';
-import { APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { MetricsIpMiddleware } from './metrics/metrics-ip.middleware';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -50,6 +51,7 @@ const metadata: ModuleMetadata = {
     SentryModule.forRoot(),
     configModule,
     typeOrmModule,
+    ThrottlerModule.forRoot([{ ttl: 60_000, limit: 60 }]),
     WinstonModule.forRoot(feedbackLoggerConfig),
     MetricsModule,
     TierModule, // 티어 시드 데이터 자동 삽입
@@ -69,6 +71,10 @@ const metadata: ModuleMetadata = {
     {
       provide: 'APP_FILTER',
       useClass: SentryGlobalFilter,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
     },
     {
       provide: APP_INTERCEPTOR,

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, NotFoundException, Query, Req, Res, UseGuards } from '@nestjs/common';
 import { ApiCookieAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+import { Throttle } from '@nestjs/throttler';
 import { Request, Response } from 'express';
 import { AuthService } from './auth.service';
 import { ConfigService } from '@nestjs/config';
@@ -19,6 +20,7 @@ export class AuthController {
   ) {}
 
   @Get('dev-login')
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
   @ApiOperation({
     summary: '개발용 로그인',
     description: '개발 환경에서만 사용 가능한 로그인 엔드포인트입니다.',
@@ -52,6 +54,7 @@ export class AuthController {
   }
 
   @Get('github')
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
   @UseGuards(AuthGuard('github'))
   @ApiOperation({
     summary: 'GitHub OAuth 로그인',
@@ -63,6 +66,7 @@ export class AuthController {
   }
 
   @Get('github/callback')
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
   @UseGuards(AuthGuard('github'))
   @ApiOperation({
     summary: 'GitHub OAuth 콜백',
@@ -89,6 +93,7 @@ export class AuthController {
   }
 
   @Get('refresh')
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
   @ApiOperation({
     summary: '토큰 갱신',
     description: 'Refresh Token을 사용하여 새로운 Access Token을 발급합니다.',

--- a/packages/backend/src/health/health.controller.ts
+++ b/packages/backend/src/health/health.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { SkipThrottle } from '@nestjs/throttler';
 
+@SkipThrottle()
 @ApiTags('health')
 @Controller('health')
 export class HealthController {

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -5,10 +5,12 @@ import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import cookieParser from 'cookie-parser';
 import compression from 'compression';
+import type { Application } from 'express';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  (app.getHttpAdapter().getInstance() as Application).set('trust proxy', 1);
   app.use(compression());
   app.use(cookieParser());
 

--- a/packages/backend/src/single-play/single-play.controller.ts
+++ b/packages/backend/src/single-play/single-play.controller.ts
@@ -9,6 +9,7 @@ import {
   UseGuards,
   ValidationPipe,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { SinglePlayService } from './single-play.service';
 import { GetQuestionDto, SubmitAnswerDto } from './dto';
@@ -137,6 +138,7 @@ export class SinglePlayController {
    * POST /api/singleplay/submit
    */
   @Post('submit')
+  @Throttle({ default: { limit: 30, ttl: 60_000 } })
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@nestjs/swagger':
         specifier: ^7.4.0
         version: 7.4.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)
+      '@nestjs/throttler':
+        specifier: ^6.5.0
+        version: 6.5.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22)(reflect-metadata@0.1.14)
       '@nestjs/typeorm':
         specifier: ^11.0.0
         version: 11.0.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.3.28(pg@8.16.3)(ts-node@10.9.2(@types/node@20.19.28)(typescript@5.9.3)))
@@ -930,6 +933,13 @@ packages:
         optional: true
       '@nestjs/platform-express':
         optional: true
+
+  '@nestjs/throttler@6.5.0':
+    resolution: {integrity: sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
 
   '@nestjs/typeorm@11.0.0':
     resolution: {integrity: sha512-SOeUQl70Lb2OfhGkvnh4KXWlsd+zA08RuuQgT7kKbzivngxzSo1Oc7Usu5VxCxACQC9wc2l9esOHILSJeK7rJA==}
@@ -5902,6 +5912,12 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@nestjs/platform-express': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22)
+
+  '@nestjs/throttler@6.5.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22)(reflect-metadata@0.1.14)':
+    dependencies:
+      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      reflect-metadata: 0.1.14
 
   '@nestjs/typeorm@11.0.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.3.28(pg@8.16.3)(ts-node@10.9.2(@types/node@20.19.28)(typescript@5.9.3)))':
     dependencies:


### PR DESCRIPTION
## 📝 개요 (Description)

모든 HTTP 엔드포인트에 Rate Limiting을 적용했습니다.

현재 인증 엔드포인트(`/auth/refresh`, `/auth/github` 등)에 반복 요청을 막을 수단이 없고, `POST /single-play/submit`은 호출마다 Clova AI API를 호출하므로 비정상 클라이언트가 반복 요청하면 외부 API 쿼터가 소진될 위험이 있습니다.

`@nestjs/throttler`를 사용해 전역 기본 제한을 설정하고, 민감도가 높은 엔드포인트에는 더 강한 제한을 적용했습니다.

| 엔드포인트 | 제한 |
|---|---|
| 전체 기본 | 60초에 60회 |
| `/auth/*` (dev-login, github, github/callback, refresh) | 60초에 10회 |
| `POST /single-play/submit` | 60초에 30회 |
| `GET /health` | 제한 없음 |

## 🔗 관련 이슈 (Related Issues)

-   Closes #270

## 🏷️ 작업 유형 (Type of Change)

-   [x] ✨ 기능 추가 (New Feature)
-   [ ] 🐛 버그 수정 (Bug Fix)
-   [x] ♻️ 리팩토링 (Refactoring)
-   [ ] 📝 문서 업데이트 (Documentation)
-   [x] 🔧 설정 변경 및 기타 (Config & Other)

## ✅ 체크리스트 (Checklist)

-   [x] 코드가 정상적으로 컴파일/빌드 되나요?
-   [x] 기존 테스트를 통과했나요? (새로운 테스트가 필요하다면 추가했나요?)
-   [x] 스스로 코드를 리뷰했나요? (Self-review)
-   [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
-   [ ] 문서(README 등)에 변경 사항을 업데이트했나요?

## 🎸 기타 (Etc)

- 제한 초과 시 응답: `429 Too Many Requests`
- `GET /health`는 모니터링 도구의 지속적인 헬스체크를 고려해 throttle에서 제외했습니다.
- submit 제한(30회/60초)은 정상 사용자가 1분에 30문제를 초과해서 풀기 어렵다는 가정 하에 설정했습니다. 실제 운영 데이터 확인 후 조정이 필요할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 애플리케이션에 요청 제한(Rate Limiting)을 도입했습니다. 글로벌 기본 제한은 분당 60회이며, 인증 엔드포인트은 분당 10회, 제출 엔드포인트는 분당 30회로 별도 제한이 적용됩니다.
  * 상태(헬스) 엔드포인트는 요청 제한에서 제외되어 정상성 확인에 영향이 없습니다.

* **Chores**
  * 런타임 종속성 추가 및 프록시 관련 서버 설정(신뢰 프록시) 변경이 포함되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->