### PR TITLE
[FEAT] 멀티 인스턴스 배포 인프라 + E2E 검증

### DIFF
--- a/docker-compose-multi.yml
+++ b/docker-compose-multi.yml
@@ -63,6 +63,13 @@ services:
         condition: service_healthy
       postgres:
         condition: service_healthy
+    healthcheck:
+      # NestJS가 실제로 listen을 시작한 뒤에야 nginx가 프록시를 시작하도록 한다
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:4000/api/health || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 30s
 
   backend-2:
     build:
@@ -92,6 +99,12 @@ services:
         condition: service_healthy
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:4000/api/health || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 30s
 
   nginx:
     image: nginx:alpine
@@ -103,8 +116,10 @@ services:
     volumes:
       - ./nginx-multi.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
-      - backend-1
-      - backend-2
+      backend-1:
+        condition: service_healthy
+      backend-2:
+        condition: service_healthy
 
 networks:
   multi-network:

--- a/docker-compose-multi.yml
+++ b/docker-compose-multi.yml
@@ -1,0 +1,114 @@
+## 멀티 인스턴스 테스트 환경
+## 사용법: docker compose -f docker-compose-multi.yml up --build
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: web05-redis-multi
+    ports:
+      - "6379:6379"
+    networks:
+      - multi-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+
+  postgres:
+    image: postgres:18.1
+    container_name: web05-postgres-multi
+    environment:
+      POSTGRES_DB: ${DB_DATABASE:-boostcamp}
+      POSTGRES_USER: ${DB_USERNAME:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
+    ports:
+      - "5432:5432"
+    networks:
+      - multi-network
+    volumes:
+      - postgres_multi_data:/var/lib/postgresql
+      - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
+    command: ["postgres", "-c", "shared_preload_libraries=pg_stat_statements", "-c", "pg_stat_statements.track=all"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-postgres} -d ${DB_DATABASE:-boostcamp}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend-1:
+    build:
+      context: .
+      dockerfile: packages/backend/Dockerfile
+    container_name: web05-backend-1
+    networks:
+      - multi-network
+    environment:
+      NODE_ENV: development
+      INSTANCE_ID: backend-1
+      CORS_ORIGIN: http://localhost
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_USERNAME: ${DB_USERNAME:-postgres}
+      DB_PASSWORD: ${DB_PASSWORD:-postgres}
+      DB_DATABASE: ${DB_DATABASE:-boostcamp}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      CLOVA_STUDIO_API_KEY: ${CLOVA_STUDIO_API_KEY:-}
+      JWT_SECRET: ${JWT_SECRET:-test_jwt_secret_for_multi_instance_32chars}
+      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET:-test_refresh_secret_for_multi_32chars}
+    ports:
+      - "4001:4000"
+    depends_on:
+      redis:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+
+  backend-2:
+    build:
+      context: .
+      dockerfile: packages/backend/Dockerfile
+    container_name: web05-backend-2
+    networks:
+      - multi-network
+    environment:
+      NODE_ENV: development
+      INSTANCE_ID: backend-2
+      CORS_ORIGIN: http://localhost
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_USERNAME: ${DB_USERNAME:-postgres}
+      DB_PASSWORD: ${DB_PASSWORD:-postgres}
+      DB_DATABASE: ${DB_DATABASE:-boostcamp}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      CLOVA_STUDIO_API_KEY: ${CLOVA_STUDIO_API_KEY:-}
+      JWT_SECRET: ${JWT_SECRET:-test_jwt_secret_for_multi_instance_32chars}
+      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET:-test_refresh_secret_for_multi_32chars}
+    ports:
+      - "4002:4000"
+    depends_on:
+      redis:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+
+  nginx:
+    image: nginx:alpine
+    container_name: web05-nginx-multi
+    ports:
+      - "80:80"
+    networks:
+      - multi-network
+    volumes:
+      - ./nginx-multi.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - backend-1
+      - backend-2
+
+networks:
+  multi-network:
+    driver: bridge
+
+volumes:
+  postgres_multi_data:

--- a/nginx-multi.conf
+++ b/nginx-multi.conf
@@ -1,0 +1,32 @@
+upstream backend_pool {
+    server backend-1:4000;
+    server backend-2:4000;
+}
+
+server {
+    listen 80;
+    server_name localhost;
+
+    # API proxy
+    location /api {
+        proxy_pass http://backend_pool;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # WebSocket proxy (라운드로빈 — sticky 없음)
+    location /socket.io {
+        proxy_pass http://backend_pool;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+}

--- a/scripts/benchmarks/package.json
+++ b/scripts/benchmarks/package.json
@@ -6,9 +6,13 @@
   "type": "module",
   "scripts": {
     "smoke:queue": "node websocket-multi-instance/smoke-test-redis-queue.mjs",
-    "smoke:command-bus": "node websocket-multi-instance/smoke-test-command-bus.mjs"
+    "smoke:command-bus": "node websocket-multi-instance/smoke-test-command-bus.mjs",
+    "e2e:cross-instance": "node websocket-multi-instance/test-cross-instance.mjs",
+    "sign-jwt": "node websocket-multi-instance/sign-jwt.mjs"
   },
   "dependencies": {
-    "ioredis": "^5.10.1"
+    "ioredis": "^5.10.1",
+    "jsonwebtoken": "^9.0.3",
+    "socket.io-client": "^4.8.3"
   }
 }

--- a/scripts/benchmarks/pnpm-lock.yaml
+++ b/scripts/benchmarks/pnpm-lock.yaml
@@ -11,11 +11,23 @@ importers:
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
+      jsonwebtoken:
+        specifier: ^9.0.3
+        version: 9.0.3
+      socket.io-client:
+        specifier: ^4.8.3
+        version: 4.8.3
 
 packages:
 
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
@@ -34,15 +46,56 @@ packages:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  engine.io-client@6.6.4:
+    resolution: {integrity: sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
   ioredis@5.10.1:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
     engines: {node: '>=12.22.0'}
 
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
   lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -55,12 +108,48 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io-parser@4.2.6:
+    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+    engines: {node: '>=10.0.0'}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
 snapshots:
 
   '@ioredis/commands@1.5.1': {}
+
+  '@socket.io/component-emitter@3.1.2': {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   cluster-key-slot@1.1.2: {}
 
@@ -69,6 +158,24 @@ snapshots:
       ms: 2.1.3
 
   denque@2.1.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  engine.io-client@6.6.4:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.18.3
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  engine.io-parser@5.2.3: {}
 
   ioredis@5.10.1:
     dependencies:
@@ -84,9 +191,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   lodash.defaults@4.2.0: {}
 
+  lodash.includes@4.3.0: {}
+
   lodash.isarguments@3.1.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
+  lodash.once@4.1.1: {}
 
   ms@2.1.3: {}
 
@@ -96,4 +241,30 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
+  safe-buffer@5.2.1: {}
+
+  semver@7.7.4: {}
+
+  socket.io-client@4.8.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-client: 6.6.4
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   standard-as-callback@2.1.0: {}
+
+  ws@8.18.3: {}
+
+  xmlhttprequest-ssl@2.1.2: {}

--- a/scripts/benchmarks/websocket-multi-instance/docker-compose-multi.override.yml
+++ b/scripts/benchmarks/websocket-multi-instance/docker-compose-multi.override.yml
@@ -1,0 +1,12 @@
+## 포트 오버라이드: 기존 dev redis(6379)/postgres(5432)와 충돌 회피
+## 사용: docker compose -f docker-compose-multi.yml -f scripts/benchmarks/websocket-multi-instance/docker-compose-multi.override.yml up -d
+services:
+  redis:
+    ports:
+      - "6380:6379"
+  postgres:
+    ports:
+      - "5433:5432"
+  nginx:
+    ports:
+      - "8080:80"

--- a/scripts/benchmarks/websocket-multi-instance/docker-compose-multi.override.yml
+++ b/scripts/benchmarks/websocket-multi-instance/docker-compose-multi.override.yml
@@ -1,12 +1,16 @@
-## 포트 오버라이드: 기존 dev redis(6379)/postgres(5432)와 충돌 회피
+## 포트 오버라이드: 기존 dev redis(6379)/postgres(5432)/nginx(80)과 충돌 회피
 ## 사용: docker compose -f docker-compose-multi.yml -f scripts/benchmarks/websocket-multi-instance/docker-compose-multi.override.yml up -d
+##
+## 주의: Compose의 ports 리스트는 기본적으로 base와 merge된다.
+## !override 태그로 base의 포트 매핑을 완전히 교체해 병합을 방지한다.
+## (Docker Compose v2.20+ 필요)
 services:
   redis:
-    ports:
+    ports: !override
       - "6380:6379"
   postgres:
-    ports:
+    ports: !override
       - "5433:5432"
   nginx:
-    ports:
+    ports: !override
       - "8080:80"

--- a/scripts/benchmarks/websocket-multi-instance/sign-jwt.mjs
+++ b/scripts/benchmarks/websocket-multi-instance/sign-jwt.mjs
@@ -1,0 +1,23 @@
+/**
+ * 테스트용 JWT 발급
+ *
+ * 사용:
+ *   cd scripts/benchmarks
+ *   pnpm install --ignore-workspace
+ *   JWT_SECRET=<backend-secret> node websocket-multi-instance/sign-jwt.mjs
+ */
+import jwt from 'jsonwebtoken';
+
+const SECRET = process.env.JWT_SECRET || 'test_jwt_secret_for_multi_instance_32chars';
+
+const users = [
+  { sub: 2, visibleId: 'dev-TestPlayer1', nickname: 'TestPlayer1', oauthProvider: 'github' },
+  { sub: 3, visibleId: 'dev-TestPlayer2', nickname: 'TestPlayer2', oauthProvider: 'github' },
+];
+
+for (const u of users) {
+  const token = jwt.sign(u, SECRET, { expiresIn: '1h' });
+  console.log(`USER ${u.sub} (${u.nickname}):`);
+  console.log(token);
+  console.log();
+}

--- a/scripts/benchmarks/websocket-multi-instance/test-cross-instance.mjs
+++ b/scripts/benchmarks/websocket-multi-instance/test-cross-instance.mjs
@@ -1,0 +1,380 @@
+/**
+ * WebSocket 크로스 인스턴스 테스트
+ *
+ * 사용법:
+ *   1. docker compose -f docker-compose-multi.yml up --build
+ *   2. node scripts/benchmarks/websocket-multi-instance/test-cross-instance.mjs
+ *
+ * 또는 로컬 단일 인스턴스 테스트:
+ *   1. Redis 실행: docker run -d -p 6379:6379 redis:7-alpine
+ *   2. REDIS_HOST=localhost pnpm --filter backend run start:dev
+ *   3. node scripts/benchmarks/websocket-multi-instance/test-cross-instance.mjs --single
+ *
+ * 필요 환경변수:
+ *   TOKEN_1 - Player 1 JWT 토큰
+ *   TOKEN_2 - Player 2 JWT 토큰
+ *   (토큰이 없으면 더미 토큰으로 연결 시도합니다)
+ */
+
+import { io } from 'socket.io-client';
+
+// ============================================================
+// 설정
+// ============================================================
+const isSingle = process.argv.includes('--single');
+
+// 멀티 인스턴스: nginx 라운드로빈 (80) 또는 직접 각 인스턴스에 연결
+const INSTANCE_1_URL = process.env.INSTANCE_1_URL || (isSingle ? 'http://localhost:4000' : 'http://localhost:4001');
+const INSTANCE_2_URL = process.env.INSTANCE_2_URL || (isSingle ? 'http://localhost:4000' : 'http://localhost:4002');
+const NGINX_URL = process.env.NGINX_URL || 'http://localhost:80';
+
+const TOKEN_1 = process.env.TOKEN_1 || 'test-token-player1';
+const TOKEN_2 = process.env.TOKEN_2 || 'test-token-player2';
+
+const TIMEOUT = 30000; // 30초 타임아웃
+
+// ============================================================
+// 유틸리티
+// ============================================================
+const log = (tag, msg) => console.log(`[${new Date().toISOString()}] [${tag}] ${msg}`);
+const pass = (name) => console.log(`  ✅ ${name}`);
+const fail = (name, err) => console.log(`  ❌ ${name}: ${err}`);
+const section = (name) => console.log(`\n${'='.repeat(60)}\n  ${name}\n${'='.repeat(60)}`);
+
+function createSocket(url, token) {
+  return io(`${url}/ws`, {
+    transports: ['websocket'],
+    auth: { token },
+    autoConnect: false,
+    reconnection: false,
+    timeout: 10000,
+  });
+}
+
+function waitForEvent(socket, event, timeoutMs = TIMEOUT) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timeout waiting for '${event}' (${timeoutMs}ms)`));
+    }, timeoutMs);
+
+    socket.once(event, (data) => {
+      clearTimeout(timer);
+      resolve(data);
+    });
+
+    socket.once('error', (err) => {
+      clearTimeout(timer);
+      reject(new Error(`Socket error: ${JSON.stringify(err)}`));
+    });
+  });
+}
+
+function waitForConnect(socket, timeoutMs = 10000) {
+  return new Promise((resolve, reject) => {
+    if (socket.connected) {
+      resolve();
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      reject(new Error(`Connection timeout (${timeoutMs}ms)`));
+    }, timeoutMs);
+
+    socket.once('connect', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+
+    socket.once('connect_error', (err) => {
+      clearTimeout(timer);
+      reject(new Error(`Connection error: ${err.message}`));
+    });
+
+    socket.connect();
+  });
+}
+
+// ============================================================
+// 테스트 1: 연결 테스트
+// ============================================================
+async function testConnection() {
+  section('Test 1: 인스턴스 연결 테스트');
+
+  const socket1 = createSocket(INSTANCE_1_URL, TOKEN_1);
+  const socket2 = createSocket(INSTANCE_2_URL, TOKEN_2);
+
+  try {
+    // Player 1 → Instance 1
+    await waitForConnect(socket1);
+    pass(`Player 1 connected to ${INSTANCE_1_URL}`);
+
+    const completed1 = await waitForEvent(socket1, 'connect:completed', 5000);
+    pass('Player 1 received connect:completed');
+
+    // Player 2 → Instance 2
+    await waitForConnect(socket2);
+    pass(`Player 2 connected to ${INSTANCE_2_URL}`);
+
+    const completed2 = await waitForEvent(socket2, 'connect:completed', 5000);
+    pass('Player 2 received connect:completed');
+
+    // 디버그: 모든 이벤트 로깅
+    socket1.onAny((event, ...args) => {
+      log('P1:EVENT', `${event} ${JSON.stringify(args).slice(0, 100)}`);
+    });
+    socket2.onAny((event, ...args) => {
+      log('P2:EVENT', `${event} ${JSON.stringify(args).slice(0, 100)}`);
+    });
+
+    return { socket1, socket2 };
+  } catch (err) {
+    fail('Connection', err.message);
+    socket1.disconnect();
+    socket2.disconnect();
+    return null;
+  }
+}
+
+// ============================================================
+// 테스트 2: 크로스 인스턴스 매칭
+// ============================================================
+async function testCrossInstanceMatching(socket1, socket2) {
+  section('Test 2: 크로스 인스턴스 매칭 테스트');
+
+  try {
+    // 이벤트 리스너를 먼저 등록 (매칭이 즉시 발생할 수 있으므로)
+    const matchFoundPromise1 = waitForEvent(socket1, 'match:found', 15000);
+    const matchFoundPromise2 = waitForEvent(socket2, 'match:found', 15000);
+
+    // Player 1 enqueue
+    socket1.emit('match:enqueue', {}, (response) => {
+      if (response.ok) {
+        log('P1', `Enqueued (sessionId: ${response.sessionId})`);
+      } else {
+        log('P1', `Enqueue failed: ${response.error}`);
+      }
+    });
+
+    // Player 2 enqueue (약간의 딜레이로 Player 1이 큐에 먼저 들어가게)
+    await new Promise(r => setTimeout(r, 1000));
+    socket2.emit('match:enqueue', {}, (response) => {
+      if (response.ok) {
+        log('P2', `Enqueued (sessionId: ${response.sessionId})`);
+      } else {
+        log('P2', `Enqueue failed: ${response.error}`);
+      }
+    });
+
+    // 매칭 대기 (폴링 간격 5초 + 여유)
+    log('WAIT', 'Waiting for match (polling interval: 5s)...');
+
+    const [match1, match2] = await Promise.all([matchFoundPromise1, matchFoundPromise2]);
+
+    pass(`Player 1 matched! Opponent: ${match1.opponent?.nickname || 'unknown'}`);
+    pass(`Player 2 matched! Opponent: ${match2.opponent?.nickname || 'unknown'}`);
+
+    return true;
+  } catch (err) {
+    fail('Cross-instance matching', err.message);
+    return false;
+  }
+}
+
+// ============================================================
+// 테스트 3: 게임 플레이 (이벤트 수신 확인)
+// ============================================================
+async function testGamePlay(socket1, socket2) {
+  section('Test 3: 게임 이벤트 수신 테스트');
+
+  try {
+    // round:ready 대기
+    const ready1Promise = waitForEvent(socket1, 'round:ready', 10000);
+    const ready2Promise = waitForEvent(socket2, 'round:ready', 10000);
+
+    const [ready1, ready2] = await Promise.all([ready1Promise, ready2Promise]);
+    pass(`Round ready received (duration: ${ready1.durationSec}s)`);
+
+    // round:start 대기 (문제 출제)
+    const start1Promise = waitForEvent(socket1, 'round:start', 10000);
+    const start2Promise = waitForEvent(socket2, 'round:start', 10000);
+
+    const [start1, start2] = await Promise.all([start1Promise, start2Promise]);
+    pass(`Round started! Question type: ${start1.question?.type || 'unknown'}`);
+
+    // Player 1 답안 제출
+    const submitPromise = new Promise((resolve, reject) => {
+      socket1.emit('submit:answer', { answer: 'test-answer' }, (response) => {
+        if (response.ok) {
+          resolve(response);
+        } else {
+          reject(new Error(response.error));
+        }
+      });
+    });
+
+    // Player 2에서 opponent:submitted 수신 확인 (Redis Adapter 크로스 인스턴스 테스트)
+    const opponentSubmittedPromise = waitForEvent(socket2, 'opponent:submitted', 10000);
+
+    const submitResult = await submitPromise;
+    pass('Player 1 submitted answer');
+
+    await opponentSubmittedPromise;
+    pass('Player 2 received opponent:submitted (cross-instance event delivery confirmed!)');
+
+    // Player 2도 답안 제출
+    const submit2Promise = new Promise((resolve, reject) => {
+      socket2.emit('submit:answer', { answer: 'test-answer-2' }, (response) => {
+        if (response.ok) {
+          resolve(response);
+        } else {
+          reject(new Error(response.error));
+        }
+      });
+    });
+
+    await submit2Promise;
+    pass('Player 2 submitted answer');
+
+    // round:end 수신 확인
+    const end1Promise = waitForEvent(socket1, 'round:end', 15000);
+    const end2Promise = waitForEvent(socket2, 'round:end', 15000);
+
+    const [end1, end2] = await Promise.all([end1Promise, end2Promise]);
+    pass(`Round ended! P1 score: ${end1.results?.my?.total}, P2 score: ${end2.results?.my?.total}`);
+
+    return true;
+  } catch (err) {
+    fail('Game play', err.message);
+    return false;
+  }
+}
+
+// ============================================================
+// 테스트 4: 연결 끊김 시 상대방 알림
+// ============================================================
+async function testDisconnectNotification(socket1, socket2) {
+  section('Test 4: 연결 끊김 알림 테스트');
+
+  try {
+    // 다음 라운드 대기
+    const ready = await waitForEvent(socket1, 'round:ready', 20000).catch(() => null);
+
+    if (!ready) {
+      log('SKIP', 'No next round — game may have ended');
+      return true;
+    }
+
+    // Player 1 강제 연결 해제
+    const disconnectPromise = waitForEvent(socket2, 'opponent:disconnected', 10000);
+
+    socket1.disconnect();
+    log('P1', 'Disconnected forcefully');
+
+    const disconnectEvent = await disconnectPromise;
+    pass(`Player 2 received opponent:disconnected (winner: ${disconnectEvent.winnerId})`);
+
+    // match:end 수신 확인
+    const matchEnd = await waitForEvent(socket2, 'match:end', 10000);
+    pass(`Player 2 received match:end (win: ${matchEnd.isWin}, tierChange: ${matchEnd.tierPointChange})`);
+
+    return true;
+  } catch (err) {
+    fail('Disconnect notification', err.message);
+    return false;
+  }
+}
+
+// ============================================================
+// 테스트 5: Redis 연결 확인 (직접 확인용)
+// ============================================================
+async function testRedisKeys() {
+  section('Test 5: Redis 키 확인 가이드');
+
+  console.log(`
+  다음 명령어로 Redis 상태를 확인하세요:
+
+  # Redis 컨테이너에 접속
+  docker exec -it web05-redis-multi redis-cli
+
+  # 매칭 큐 확인
+  ZRANGEBYSCORE matchmaking:queue -inf +inf WITHSCORES
+
+  # 매칭 세션 키 확인
+  KEYS mm:*
+
+  # 게임 커맨드 채널 구독 모니터링
+  SUBSCRIBE game:commands
+
+  # 매치 락 확인
+  KEYS match:lock:*
+
+  # 전체 키 목록
+  KEYS *
+  `);
+}
+
+// ============================================================
+// 메인 실행
+// ============================================================
+async function main() {
+  console.log(`
+╔══════════════════════════════════════════════════╗
+║  CSArena WebSocket 크로스 인스턴스 테스트        ║
+╠══════════════════════════════════════════════════╣
+║  Instance 1: ${INSTANCE_1_URL.padEnd(35)}║
+║  Instance 2: ${INSTANCE_2_URL.padEnd(35)}║
+║  Mode: ${(isSingle ? 'Single Instance' : 'Multi Instance').padEnd(42)}║
+╚══════════════════════════════════════════════════╝
+  `);
+
+  let socket1, socket2;
+  let results = { pass: 0, fail: 0 };
+
+  try {
+    // Test 1: 연결
+    const connections = await testConnection();
+    if (!connections) {
+      console.log('\n⚠️  연결 실패 — 서버가 실행 중인지 확인하세요.');
+      console.log('  docker compose -f docker-compose-multi.yml up --build');
+      process.exit(1);
+    }
+    socket1 = connections.socket1;
+    socket2 = connections.socket2;
+    results.pass++;
+
+    // Test 2: 크로스 인스턴스 매칭
+    const matched = await testCrossInstanceMatching(socket1, socket2);
+    matched ? results.pass++ : results.fail++;
+
+    if (matched) {
+      // Test 3: 게임 플레이
+      const played = await testGamePlay(socket1, socket2);
+      played ? results.pass++ : results.fail++;
+
+      // Test 4: 연결 끊김
+      if (played) {
+        const disconnected = await testDisconnectNotification(socket1, socket2);
+        disconnected ? results.pass++ : results.fail++;
+      }
+    }
+
+    // Test 5: Redis 키 가이드
+    await testRedisKeys();
+
+  } catch (err) {
+    console.error('\n💥 Unexpected error:', err);
+    results.fail++;
+  } finally {
+    if (socket1?.connected) socket1.disconnect();
+    if (socket2?.connected) socket2.disconnect();
+
+    section('테스트 결과');
+    console.log(`  통과: ${results.pass}`);
+    console.log(`  실패: ${results.fail}`);
+    console.log(`  총계: ${results.pass + results.fail}`);
+
+    process.exit(results.fail > 0 ? 1 : 0);
+  }
+}
+
+main();

--- a/scripts/benchmarks/websocket-multi-instance/test-cross-instance.mjs
+++ b/scripts/benchmarks/websocket-multi-instance/test-cross-instance.mjs
@@ -141,6 +141,16 @@ async function testConnection() {
 async function testCrossInstanceMatching(socket1, socket2) {
   section('Test 2: 크로스 인스턴스 매칭 테스트');
 
+  // ⚠️ 매칭 후 이어지는 게임 이벤트(round:ready/start)도 match:found 직후 즉시 도달하므로,
+  //    Test 3에서 리스너를 등록하면 이미 발행된 이벤트를 놓친다.
+  //    여기서 미리 Promise로 예약해 Test 3에게 전달한다.
+  const gameEvents = {
+    ready1: waitForEvent(socket1, 'round:ready', 15000),
+    ready2: waitForEvent(socket2, 'round:ready', 15000),
+    start1: waitForEvent(socket1, 'round:start', 15000),
+    start2: waitForEvent(socket2, 'round:start', 15000),
+  };
+
   try {
     // 이벤트 리스너를 먼저 등록 (매칭이 즉시 발생할 수 있으므로)
     const matchFoundPromise1 = waitForEvent(socket1, 'match:found', 15000);
@@ -173,47 +183,46 @@ async function testCrossInstanceMatching(socket1, socket2) {
     pass(`Player 1 matched! Opponent: ${match1.opponent?.nickname || 'unknown'}`);
     pass(`Player 2 matched! Opponent: ${match2.opponent?.nickname || 'unknown'}`);
 
-    return true;
+    return { ok: true, gameEvents };
   } catch (err) {
     fail('Cross-instance matching', err.message);
-    return false;
+    return { ok: false };
   }
 }
 
 // ============================================================
 // 테스트 3: 게임 플레이 (이벤트 수신 확인)
 // ============================================================
-async function testGamePlay(socket1, socket2) {
+async function testGamePlay(socket1, socket2, gameEvents) {
   section('Test 3: 게임 이벤트 수신 테스트');
 
   try {
-    // round:ready 대기
-    const ready1Promise = waitForEvent(socket1, 'round:ready', 10000);
-    const ready2Promise = waitForEvent(socket2, 'round:ready', 10000);
-
-    const [ready1, ready2] = await Promise.all([ready1Promise, ready2Promise]);
+    // round:ready/start 리스너는 Test 2에서 미리 등록된 Promise를 재사용
+    // (match:found 직후 이벤트가 즉시 발행되므로 이 시점에 등록하면 놓침)
+    const [ready1] = await Promise.all([gameEvents.ready1, gameEvents.ready2]);
     pass(`Round ready received (duration: ${ready1.durationSec}s)`);
 
-    // round:start 대기 (문제 출제)
-    const start1Promise = waitForEvent(socket1, 'round:start', 10000);
-    const start2Promise = waitForEvent(socket2, 'round:start', 10000);
-
-    const [start1, start2] = await Promise.all([start1Promise, start2Promise]);
+    const [start1] = await Promise.all([gameEvents.start1, gameEvents.start2]);
     pass(`Round started! Question type: ${start1.question?.type || 'unknown'}`);
 
-    // Player 1 답안 제출
+    // ⚠️ 리스너를 emit 전에 먼저 등록 — 백엔드가 ack 반환 전에 opponent:submitted를 emit하므로
+    //    리스너 등록이 emit 이후면 이벤트를 놓쳐 타임아웃으로 실패한다
+    const opponentSubmittedPromise = waitForEvent(socket2, 'opponent:submitted', 10000);
+
+    // Player 1 답안 제출 — Socket.IO의 .timeout()으로 CI hang 방지
     const submitPromise = new Promise((resolve, reject) => {
-      socket1.emit('submit:answer', { answer: 'test-answer' }, (response) => {
-        if (response.ok) {
+      socket1.timeout(5000).emit('submit:answer', { answer: 'test-answer' }, (err, response) => {
+        if (err) {
+          reject(new Error('submit:answer ack timeout (5s)'));
+          return;
+        }
+        if (response?.ok) {
           resolve(response);
         } else {
-          reject(new Error(response.error));
+          reject(new Error(response?.error || 'submit failed'));
         }
       });
     });
-
-    // Player 2에서 opponent:submitted 수신 확인 (Redis Adapter 크로스 인스턴스 테스트)
-    const opponentSubmittedPromise = waitForEvent(socket2, 'opponent:submitted', 10000);
 
     const submitResult = await submitPromise;
     pass('Player 1 submitted answer');
@@ -223,11 +232,15 @@ async function testGamePlay(socket1, socket2) {
 
     // Player 2도 답안 제출
     const submit2Promise = new Promise((resolve, reject) => {
-      socket2.emit('submit:answer', { answer: 'test-answer-2' }, (response) => {
-        if (response.ok) {
+      socket2.timeout(5000).emit('submit:answer', { answer: 'test-answer-2' }, (err, response) => {
+        if (err) {
+          reject(new Error('submit:answer ack timeout (5s)'));
+          return;
+        }
+        if (response?.ok) {
           resolve(response);
         } else {
-          reject(new Error(response.error));
+          reject(new Error(response?.error || 'submit failed'));
         }
       });
     });
@@ -342,13 +355,13 @@ async function main() {
     socket2 = connections.socket2;
     results.pass++;
 
-    // Test 2: 크로스 인스턴스 매칭
-    const matched = await testCrossInstanceMatching(socket1, socket2);
-    matched ? results.pass++ : results.fail++;
+    // Test 2: 크로스 인스턴스 매칭 — 이후 게임 이벤트 리스너를 미리 예약해 반환
+    const matchResult = await testCrossInstanceMatching(socket1, socket2);
+    matchResult.ok ? results.pass++ : results.fail++;
 
-    if (matched) {
-      // Test 3: 게임 플레이
-      const played = await testGamePlay(socket1, socket2);
+    if (matchResult.ok) {
+      // Test 3: 게임 플레이 — Test 2에서 예약한 이벤트 Promise 재사용
+      const played = await testGamePlay(socket1, socket2, matchResult.gameEvents);
       played ? results.pass++ : results.fail++;
 
       // Test 4: 연결 끊김


### PR DESCRIPTION
## 📝 개요 (Description)

매치 세션/큐 Redis 이관 + Socket.IO Adapter + GameCommandBus로 애플리케이션 레벨 수평 확장 준비가 끝났습니다. 이 PR은 이를 재현 가능한 배포 환경 + E2E 자동 검증으로 패키징합니다.     

## 🔗 관련 이슈 (Related Issues)

-   Closes #274

## 🏷️ 작업 유형 (Type of Change)

-   [ ] ✨ 기능 추가 (New Feature)
-   [ ] 🐛 버그 수정 (Bug Fix)
-   [ ] ♻️ 리팩토링 (Refactoring)
-   [ ] 📝 문서 업데이트 (Documentation)
-   [ ] 🔧 설정 변경 및 기타 (Config & Other)

## ✅ 체크리스트 (Checklist)

-   [x] 코드가 정상적으로 컴파일/빌드 되나요?
-   [x] 기존 테스트를 통과했나요? (새로운 테스트가 필요하다면 추가했나요?)
-   [x] 스스로 코드를 리뷰했나요? (Self-review)
-   [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
-   [x] 문서(README 등)에 변경 사항을 업데이트했나요?


## 🎸 기타 (Etc)
                                                                                                                                                                                                                                                                                                      
  실행 흐름 (재현 가능)                                                                                                                                                                                                                                                                                            
  1. 멀티 스택 기동 (dev 스택과 병행하려면 override 같이) 
  docker compose -f docker-compose-multi.yml up -d --build 
                                                                                                                                                                                                                                                                                                                   
  2. 벤치마크 디렉터리 의존성 설치                                                                                                                                                                                                                                                                               
  cd scripts/benchmarks && pnpm install --ignore-workspace                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                   
  3. 테스트 유저 JWT 발급                                                                                                                                                                                                                                                                                        
  JWT_SECRET=<backend-secret> pnpm sign-jwt
                                                                                                                                                                                                                                                                                                                   
  4. E2E 테스트                                                                                                                                                                                                                                                                                                  
  TOKEN_1=<t1> TOKEN_2=<t2> pnpm e2e:cross-instance

  리뷰 포인트                                                                                                                                                                                                                                                                                                      
  - nginx에서 sticky session을 의도적으로 끄고 라운드로빈만 구성한 부분 —  Adapter + CommandBus로 해결했기 때문에 가능
  - Player1은 :4001, Player2는 :4002에 강제 접속시켜 실제 크로스 인스턴스 상황을 재현                                                                                                                                                                                                                              
  - docker-compose-multi.override.yml로 dev 스택과 포트 충돌 없이 병행 가능      


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 여러 서버 인스턴스 간 실시간 웹소켓 통신을 검증하는 엔드투엔드 테스트 추가
  * 플레이어 매칭·게임플레이 동작을 크로스 인스턴스 환경에서 검증하는 시나리오 추가

* **기타**
  * 로컬 다중 인스턴스 개발 환경 및 로드밸런싱(프록시/웹소켓 지원) 구성 추가
  * 테스트용 JWT 토큰 생성 유틸리티 및 실행 스크립트 추가
* **환경**
  * 로컬 포트 매핑을 손쉽게 재정의할 수 있는 구성 옵션 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->