### PR TITLE
[REFACTOR] Game Timer 관련 분산 환경에 맞지 않는 문제 해결(BullMQ)

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,6 +18,7 @@
     "clean": "rm -rf dist node_modules"
   },
   "dependencies": {
+    "@nestjs/bullmq": "^11.0.4",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^10.0.0",
@@ -32,6 +33,7 @@
     "@sentry/nestjs": "^10.38.0",
     "@socket.io/redis-adapter": "^8.3.0",
     "@willsoto/nestjs-prometheus": "^6.0.2",
+    "bullmq": "^5.76.0",
     "compression": "^1.8.1",
     "cookie-parser": "^1.4.7",
     "ioredis": "^5.10.1",

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -1,6 +1,7 @@
 import { MiddlewareConsumer, Module, ModuleMetadata, NestModule } from '@nestjs/common';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import { BullModule } from '@nestjs/bullmq';
 import { MetricsIpMiddleware } from './metrics/metrics-ip.middleware';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -53,6 +54,16 @@ const metadata: ModuleMetadata = {
     configModule,
     typeOrmModule,
     ThrottlerModule.forRoot([{ ttl: 60_000, limit: 60 }]),
+    BullModule.forRootAsync({
+      imports: [ConfigModule],
+      useFactory: (configService: ConfigService) => ({
+        connection: {
+          host: configService.get('REDIS_HOST', 'localhost'),
+          port: parseInt(configService.get('REDIS_PORT', '6379'), 10),
+        },
+      }),
+      inject: [ConfigService],
+    }),
     WinstonModule.forRoot(feedbackLoggerConfig),
     MetricsModule,
     RedisModule,

--- a/packages/backend/src/game/game-command-bus.ts
+++ b/packages/backend/src/game/game-command-bus.ts
@@ -9,13 +9,14 @@ const COMMAND_CHANNEL_PREFIX = 'game:commands';
 const RESPONSE_CHANNEL_PREFIX = 'game:responses';
 
 export interface GameCommand {
-  type: 'submit_answer' | 'disconnect';
+  type: 'submit_answer' | 'disconnect' | 'phase_timeout';
   correlationId: string;
   roomId: string;
   userId: string;
   payload?: {
     answer?: string;
     socketId?: string;
+    phase?: string;
   };
 }
 

--- a/packages/backend/src/game/game.gateway.ts
+++ b/packages/backend/src/game/game.gateway.ts
@@ -66,6 +66,18 @@ export class GameGateway implements OnGatewayDisconnect, OnGatewayInit, OnModule
       return { correlationId, ok: true };
     }
 
+    if (type === 'phase_timeout') {
+      const phase = payload?.phase as 'ready' | 'question' | 'review' | undefined;
+
+      if (!phase) {
+        return { correlationId, ok: false, error: 'Missing phase in phase_timeout command' };
+      }
+
+      await this.roundProgression.handleTimerExpired(roomId, phase);
+
+      return { correlationId, ok: true };
+    }
+
     return { correlationId, ok: false, error: `Unknown command type: ${String(type)}` };
   }
 
@@ -134,7 +146,7 @@ export class GameGateway implements OnGatewayDisconnect, OnGatewayInit, OnModule
 
       // 양쪽 모두 제출했으면 그레이딩 시작
       if (this.sessionManager.isAllSubmitted(roomId)) {
-        this.roundTimer.clearQuestionTimer(roomId);
+        await this.roundTimer.clearQuestionTimer(roomId);
         this.roundTimer.clearTickInterval(roomId);
         await this.roundProgression.phaseGrading(roomId);
       }
@@ -186,7 +198,7 @@ export class GameGateway implements OnGatewayDisconnect, OnGatewayInit, OnModule
    * 연결 끊김 처리 (로컬 + 원격 커맨드 버스 모두에서 호출)
    */
   private async processDisconnect(roomId: string, userId: string): Promise<void> {
-    this.roundTimer.clearAllTimers(roomId);
+    await this.roundTimer.clearAllTimers(roomId);
 
     const gameSession = this.sessionManager.getGameSession(roomId);
 

--- a/packages/backend/src/game/game.gateway.ts
+++ b/packages/backend/src/game/game.gateway.ts
@@ -67,10 +67,14 @@ export class GameGateway implements OnGatewayDisconnect, OnGatewayInit, OnModule
     }
 
     if (type === 'phase_timeout') {
-      const phase = payload?.phase as 'ready' | 'question' | 'review' | undefined;
+      const phase = payload?.phase;
 
-      if (!phase) {
-        return { correlationId, ok: false, error: 'Missing phase in phase_timeout command' };
+      if (phase !== 'ready' && phase !== 'question' && phase !== 'review') {
+        return { correlationId, ok: false, error: `Invalid phase: ${String(phase)}` };
+      }
+
+      if (!this.sessionManager.getGameSession(roomId)) {
+        return { correlationId, ok: false, error: 'No local session' };
       }
 
       await this.roundProgression.handleTimerExpired(roomId, phase);

--- a/packages/backend/src/game/game.module.ts
+++ b/packages/backend/src/game/game.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bullmq';
 import { GameGateway } from './game.gateway';
 import { GameSessionManager } from './game-session-manager';
 import { QuizModule } from '../quiz/quiz.module';
@@ -12,6 +13,9 @@ import { RoundProgressionService } from './round-progression.service';
 import { RoundTimer } from './round-timer';
 import { MatchPersistenceService } from './match-persistence.service';
 import { GameCommandBus } from './game-command-bus';
+import { MATCH_PERSISTENCE_QUEUE, ROUND_TIMER_QUEUE } from './queues/queue.constants';
+import { RoundTimerWorker } from './workers/round-timer.worker';
+import { MatchPersistenceWorker } from './workers/match-persistence.worker';
 
 @Module({
   imports: [
@@ -24,6 +28,7 @@ import { GameCommandBus } from './game-command-bus';
       UserStatistics,
       UserTierHistory,
     ]),
+    BullModule.registerQueue({ name: ROUND_TIMER_QUEUE }, { name: MATCH_PERSISTENCE_QUEUE }),
   ],
   providers: [
     GameGateway,
@@ -32,6 +37,8 @@ import { GameCommandBus } from './game-command-bus';
     RoundTimer,
     MatchPersistenceService,
     GameCommandBus,
+    RoundTimerWorker,
+    MatchPersistenceWorker,
   ],
   exports: [GameSessionManager, RoundProgressionService],
 })

--- a/packages/backend/src/game/match-persistence.service.ts
+++ b/packages/backend/src/game/match-persistence.service.ts
@@ -131,6 +131,7 @@ export class MatchPersistenceService {
       'save-match',
       { snapshot, finalResult },
       {
+        jobId: `save-match:${snapshot.roomId}`,
         attempts: 5,
         backoff: { type: 'exponential', delay: 1000 },
         removeOnComplete: true,

--- a/packages/backend/src/game/match-persistence.service.ts
+++ b/packages/backend/src/game/match-persistence.service.ts
@@ -1,8 +1,16 @@
 import { HttpException, Injectable, Logger } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
 import { DataSource, EntityManager } from 'typeorm';
 import { GameSessionManager } from './game-session-manager';
 import { QuizService } from '../quiz/quiz.service';
-import { FinalResult, GameSession } from './interfaces/game.interfaces';
+import {
+  FinalResult,
+  GameSession,
+  GradeResult,
+  RoundResult,
+  Submission,
+} from './interfaces/game.interfaces';
 import { Match, Round, RoundAnswer } from '../match/entity';
 import { UserProblemBank } from '../problem-bank/entity';
 import { UserStatistics } from '../user/entity';
@@ -10,6 +18,7 @@ import { Tier, UserTierHistory } from '../tier/entity';
 import { calculateMatchEloUpdate } from '../common/utils/elo.util';
 import { calculateTier } from '../common/utils/tier.util';
 import { parseUserId } from '../common/utils/parse-user-id.util';
+import { MATCH_PERSISTENCE_QUEUE } from './queues/queue.constants';
 
 class NonRetryableError extends Error {
   constructor(message: string) {
@@ -19,21 +28,45 @@ class NonRetryableError extends Error {
   }
 }
 
+export interface SerializedRoundData {
+  roundNumber: number;
+  questionId: number | null;
+  questionType: string | null;
+  submissions: { [playerId: string]: Submission | null };
+  result: RoundResult | null;
+}
+
+export interface SessionSnapshot {
+  roomId: string;
+  player1Id: string;
+  player2Id: string;
+  player1Score: number;
+  player2Score: number;
+  rounds: SerializedRoundData[];
+}
+
+export interface MatchPersistenceJobData {
+  snapshot: SessionSnapshot;
+  finalResult: FinalResult;
+}
+
 @Injectable()
 export class MatchPersistenceService {
   private readonly logger = new Logger(MatchPersistenceService.name);
-  private readonly MAX_RETRIES = 5;
-  private readonly BASE_DELAY = 1000;
 
   constructor(
     private readonly connection: DataSource,
     private readonly sessionManager: GameSessionManager,
     private readonly quizService: QuizService,
+    @InjectQueue(MATCH_PERSISTENCE_QUEUE)
+    private readonly persistenceQueue: Queue<MatchPersistenceJobData>,
   ) {}
 
   /**
-   * 매치 종료 후 DB에 결과 저장 (Batch INSERT, 지수 백오프 재시도)
-   * @returns ELO 변화량 정보 { player1Change, player2Change }
+   * 매치 종료 후 DB에 결과 저장
+   *
+   * 1차 시도는 동기 경로로 즉시 실행 → ELO 변화량을 바로 반환 가능.
+   * 실패 시 세션 스냅샷을 BullMQ 큐에 저장 → Redis 기반 영속적 재시도.
    */
   async saveMatchToDatabase(
     roomId: string,
@@ -47,73 +80,92 @@ export class MatchPersistenceService {
       return null;
     }
 
-    for (let attempt = 1; attempt <= this.MAX_RETRIES; attempt++) {
-      try {
-        let eloChanges: { player1Change: number; player2Change: number } | null = null;
+    const snapshot = this.createSnapshot(session);
 
-        await this.connection.transaction(async (manager) => {
-          const matchId = await this.insertMatch(manager, session, finalResult);
-          const roundIdMap = await this.insertRounds(manager, matchId, session);
-          await this.insertRoundAnswers(manager, roundIdMap, session);
-          await this.insertUserProblemBanks(manager, matchId, session);
+    try {
+      return await this.executeTransaction(snapshot, finalResult);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 
-          // ELO 업데이트 (무승부가 아닐 때만)
-          if (!finalResult.isDraw && finalResult.winnerId) {
-            eloChanges = await this.updateEloRatings(manager, matchId, session, finalResult);
-          }
-        });
+      if (error instanceof HttpException || error instanceof NonRetryableError) {
+        this.logger.error(`매치 저장 실패 (재시도 불가) - room: ${roomId}`, errorMessage);
 
-        return eloChanges;
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-        const errorStack = error instanceof Error ? error.stack : undefined;
-
-        if (
-          error instanceof HttpException ||
-          (error instanceof Error && error.name === 'NonRetryableError')
-        ) {
-          this.logger.error(
-            `매치 저장 실패 (재시도 불가) - room: ${roomId}`,
-            JSON.stringify({ roomId, finalResult, error: errorMessage }),
-          );
-
-          return null;
-        }
-
-        const delay = this.calculateBackoff(attempt);
-
-        if (attempt < this.MAX_RETRIES) {
-          this.logger.warn(
-            `매치 저장 실패 - room: ${roomId} (${attempt}/${this.MAX_RETRIES}회), ${delay}ms 후 재시도`,
-            errorStack,
-          );
-          await this.delay(delay);
-        } else {
-          this.logger.error(
-            `매치 저장 최종 실패 - room: ${roomId}. 데이터 유실 가능성 있음.`,
-            JSON.stringify({ roomId, finalResult, error: errorMessage }),
-          );
-        }
+        return null;
       }
+
+      this.logger.warn(
+        `매치 저장 1차 실패 - room: ${roomId}, BullMQ 재시도 큐에 등록: ${errorMessage}`,
+      );
+      await this.enqueueRetry(snapshot, finalResult);
+
+      return null;
     }
-
-    return null;
-  }
-
-  private calculateBackoff(attempt: number): number {
-    return this.BASE_DELAY * Math.pow(2, attempt - 1);
-  }
-
-  private delay(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   /**
-   * Match 테이블에 INSERT
+   * BullMQ 워커에서 호출: 스냅샷으로 DB 저장
    */
+  async saveMatchFromSnapshot(snapshot: SessionSnapshot, finalResult: FinalResult): Promise<void> {
+    await this.executeTransaction(snapshot, finalResult);
+  }
+
+  private createSnapshot(session: GameSession): SessionSnapshot {
+    return {
+      roomId: session.roomId,
+      player1Id: session.player1Id,
+      player2Id: session.player2Id,
+      player1Score: session.player1Score,
+      player2Score: session.player2Score,
+      rounds: Array.from(session.rounds.values()).map((round) => ({
+        roundNumber: round.roundNumber,
+        questionId: round.questionId,
+        questionType: round.question?.questionType ?? null,
+        submissions: round.submissions,
+        result: round.result,
+      })),
+    };
+  }
+
+  private async enqueueRetry(snapshot: SessionSnapshot, finalResult: FinalResult): Promise<void> {
+    await this.persistenceQueue.add(
+      'save-match',
+      { snapshot, finalResult },
+      {
+        attempts: 5,
+        backoff: { type: 'exponential', delay: 1000 },
+        removeOnComplete: true,
+        removeOnFail: false,
+      },
+    );
+    this.logger.log(`매치 ${snapshot.roomId} 재시도 큐 등록 완료`);
+  }
+
+  /**
+   * 트랜잭션 실행 (스냅샷 기반)
+   */
+  private async executeTransaction(
+    snapshot: SessionSnapshot,
+    finalResult: FinalResult,
+  ): Promise<{ player1Change: number; player2Change: number } | null> {
+    let eloChanges: { player1Change: number; player2Change: number } | null = null;
+
+    await this.connection.transaction(async (manager) => {
+      const matchId = await this.insertMatch(manager, snapshot, finalResult);
+      const roundIdMap = await this.insertRounds(manager, matchId, snapshot);
+      await this.insertRoundAnswers(manager, roundIdMap, snapshot);
+      await this.insertUserProblemBanks(manager, matchId, snapshot);
+
+      if (!finalResult.isDraw && finalResult.winnerId) {
+        eloChanges = await this.updateEloRatings(manager, matchId, snapshot, finalResult);
+      }
+    });
+
+    return eloChanges;
+  }
+
   private async insertMatch(
     manager: EntityManager,
-    session: GameSession,
+    snapshot: SessionSnapshot,
     finalResult: FinalResult,
   ): Promise<number> {
     const result = await manager
@@ -121,8 +173,8 @@ export class MatchPersistenceService {
       .insert()
       .into(Match)
       .values({
-        player1Id: parseUserId(session.player1Id),
-        player2Id: parseUserId(session.player2Id),
+        player1Id: parseUserId(snapshot.player1Id),
+        player2Id: parseUserId(snapshot.player2Id),
         winnerId: finalResult.winnerId ? parseUserId(finalResult.winnerId) : null,
         matchType: 'multi',
       })
@@ -138,18 +190,15 @@ export class MatchPersistenceService {
     return generated.id as number;
   }
 
-  /**
-   * Rounds 테이블에 Bulk INSERT
-   */
   private async insertRounds(
     manager: EntityManager,
     matchId: number,
-    session: GameSession,
+    snapshot: SessionSnapshot,
   ): Promise<Map<number, number>> {
-    const roundsData = Array.from(session.rounds.entries()).map(([roundNum, roundData]) => ({
+    const roundsData = snapshot.rounds.map((round) => ({
       matchId,
-      questionId: roundData.questionId,
-      roundNumber: roundNum,
+      questionId: round.questionId,
+      roundNumber: round.roundNumber,
     }));
 
     const result = await manager
@@ -173,50 +222,44 @@ export class MatchPersistenceService {
     return roundIdMap;
   }
 
-  /**
-   * RoundAnswers 테이블에 Bulk INSERT
-   */
   private async insertRoundAnswers(
     manager: EntityManager,
     roundIdMap: Map<number, number>,
-    session: GameSession,
+    snapshot: SessionSnapshot,
   ): Promise<void> {
-    const answersData = this.prepareRoundAnswersData(roundIdMap, session);
+    const answersData = this.prepareRoundAnswersData(roundIdMap, snapshot);
 
     if (answersData.length > 0) {
       await manager.createQueryBuilder().insert().into(RoundAnswer).values(answersData).execute();
     }
   }
 
-  /**
-   * RoundAnswers INSERT용 데이터 준비
-   */
   private prepareRoundAnswersData(
     roundIdMap: Map<number, number>,
-    session: GameSession,
+    snapshot: SessionSnapshot,
   ): Partial<RoundAnswer>[] {
     const answersData: Partial<RoundAnswer>[] = [];
 
-    for (const [roundNum, roundData] of session.rounds.entries()) {
-      const roundId = roundIdMap.get(roundNum);
-      const questionType = roundData.question?.questionType;
+    for (const round of snapshot.rounds) {
+      const roundId = roundIdMap.get(round.roundNumber);
+      const questionType = round.questionType;
 
       if (roundId === undefined) {
-        this.logger.warn(`roundId 없음: round ${roundNum}`);
+        this.logger.warn(`roundId 없음: round ${round.roundNumber}`);
         continue;
       }
 
       if (!questionType) {
-        this.logger.warn(`questionType 없음: round ${roundNum}`);
+        this.logger.warn(`questionType 없음: round ${round.roundNumber}`);
         continue;
       }
 
-      for (const [playerId, submission] of Object.entries(roundData.submissions)) {
+      for (const [playerId, submission] of Object.entries(round.submissions)) {
         if (!submission) {
           continue;
         }
 
-        const grade = roundData.result?.grades.find((g) => g.playerId === playerId);
+        const grade = round.result?.grades.find((g: GradeResult) => g.playerId === playerId);
 
         if (!grade) {
           continue;
@@ -240,15 +283,12 @@ export class MatchPersistenceService {
     return answersData;
   }
 
-  /**
-   * UserProblemBanks 테이블에 Bulk INSERT
-   */
   private async insertUserProblemBanks(
     manager: EntityManager,
     matchId: number,
-    session: GameSession,
+    snapshot: SessionSnapshot,
   ): Promise<void> {
-    const problemBanksData = this.prepareProblemBanksData(matchId, session);
+    const problemBanksData = this.prepareProblemBanksData(matchId, snapshot);
 
     if (problemBanksData.length > 0) {
       await manager
@@ -260,29 +300,26 @@ export class MatchPersistenceService {
     }
   }
 
-  /**
-   * UserProblemBanks INSERT용 데이터 준비
-   */
   private prepareProblemBanksData(
     matchId: number,
-    session: GameSession,
+    snapshot: SessionSnapshot,
   ): Partial<UserProblemBank>[] {
     const problemBanksData: Partial<UserProblemBank>[] = [];
 
-    for (const [roundNum, roundData] of session.rounds.entries()) {
-      const questionType = roundData.question?.questionType;
+    for (const round of snapshot.rounds) {
+      const questionType = round.questionType;
 
       if (!questionType) {
-        this.logger.warn(`questionType 없음 (problemBank): round ${roundNum}`);
+        this.logger.warn(`questionType 없음 (problemBank): round ${round.roundNumber}`);
         continue;
       }
 
-      for (const [playerId, submission] of Object.entries(roundData.submissions)) {
+      for (const [playerId, submission] of Object.entries(round.submissions)) {
         if (!submission) {
           continue;
         }
 
-        const grade = roundData.result?.grades.find((g) => g.playerId === playerId);
+        const grade = round.result?.grades.find((g: GradeResult) => g.playerId === playerId);
 
         if (!grade) {
           continue;
@@ -290,7 +327,7 @@ export class MatchPersistenceService {
 
         problemBanksData.push({
           userId: parseUserId(playerId),
-          questionId: roundData.questionId,
+          questionId: round.questionId,
           matchId,
           userAnswer: submission.answer || '',
           answerStatus: this.quizService.determineAnswerStatus(
@@ -306,35 +343,20 @@ export class MatchPersistenceService {
     return problemBanksData;
   }
 
-  /**
-   * ELO 레이팅 업데이트
-   *
-   * @param manager - 트랜잭션 매니저
-   * @param matchId - 매치 ID
-   * @param session - 게임 세션
-   * @param finalResult - 게임 결과
-   * @returns ELO 변화량 { player1Change, player2Change }
-   */
   private async updateEloRatings(
     manager: EntityManager,
     matchId: number,
-    session: GameSession,
+    snapshot: SessionSnapshot,
     finalResult: FinalResult,
   ): Promise<{ player1Change: number; player2Change: number }> {
     const winnerId = parseUserId(finalResult.winnerId);
     const loserId =
-      parseUserId(session.player1Id) === winnerId
-        ? parseUserId(session.player2Id)
-        : parseUserId(session.player1Id);
+      parseUserId(snapshot.player1Id) === winnerId
+        ? parseUserId(snapshot.player2Id)
+        : parseUserId(snapshot.player1Id);
 
-    // 현재 통계 조회
-    const winnerStats = await manager.findOne(UserStatistics, {
-      where: { userId: winnerId },
-    });
-
-    const loserStats = await manager.findOne(UserStatistics, {
-      where: { userId: loserId },
-    });
+    const winnerStats = await manager.findOne(UserStatistics, { where: { userId: winnerId } });
+    const loserStats = await manager.findOne(UserStatistics, { where: { userId: loserId } });
 
     if (!winnerStats) {
       throw new NonRetryableError(`승자의 UserStatistics를 찾을 수 없습니다. userId: ${winnerId}`);
@@ -349,7 +371,6 @@ export class MatchPersistenceService {
     const winnerTotalGames = winnerStats.totalMatches ?? 0;
     const loserTotalGames = loserStats.totalMatches ?? 0;
 
-    // ELO 계산
     const { winnerNewRating, loserNewRating, winnerChange, loserChange } = calculateMatchEloUpdate(
       winnerElo,
       loserElo,
@@ -362,7 +383,6 @@ export class MatchPersistenceService {
         `패자: ${loserId} (${loserElo} → ${loserNewRating}, ${loserChange})`,
     );
 
-    // UserStatistics 업데이트 (승패 기록 + ELO)
     await manager.update(
       UserStatistics,
       { userId: winnerId },
@@ -383,13 +403,11 @@ export class MatchPersistenceService {
       },
     );
 
-    // 티어 변동 히스토리 기록
     await this.recordTierHistory(manager, winnerId, matchId, winnerChange, winnerNewRating);
     await this.recordTierHistory(manager, loserId, matchId, loserChange, loserNewRating);
 
-    // player1과 player2의 변화량 반환
-    const player1Id = parseUserId(session.player1Id);
-    const player2Id = parseUserId(session.player2Id);
+    const player1Id = parseUserId(snapshot.player1Id);
+    const player2Id = parseUserId(snapshot.player2Id);
 
     return {
       player1Change: player1Id === winnerId ? winnerChange : loserChange,
@@ -397,15 +415,6 @@ export class MatchPersistenceService {
     };
   }
 
-  /**
-   * 티어 변동 히스토리 기록
-   *
-   * @param manager - 트랜잭션 매니저
-   * @param userId - 유저 ID
-   * @param matchId - 매치 ID
-   * @param tierChange - 티어 변화량
-   * @param newElo - 새로운 ELO
-   */
   private async recordTierHistory(
     manager: EntityManager,
     userId: number,
@@ -414,10 +423,7 @@ export class MatchPersistenceService {
     newElo: number,
   ): Promise<void> {
     const tierName = calculateTier(newElo);
-
-    const tier = await manager.findOne(Tier, {
-      where: { name: tierName },
-    });
+    const tier = await manager.findOne(Tier, { where: { name: tierName } });
 
     if (!tier) {
       throw new NonRetryableError(

--- a/packages/backend/src/game/queues/queue.constants.ts
+++ b/packages/backend/src/game/queues/queue.constants.ts
@@ -1,0 +1,2 @@
+export const ROUND_TIMER_QUEUE = 'round-timer';
+export const MATCH_PERSISTENCE_QUEUE = 'match-persistence';

--- a/packages/backend/src/game/round-progression.service.ts
+++ b/packages/backend/src/game/round-progression.service.ts
@@ -41,18 +41,32 @@ export class RoundProgressionService {
    * BullMQ 워커에서 호출: 페이즈 타임아웃 처리
    */
   async handleTimerExpired(roomId: string, phase: 'ready' | 'question' | 'review'): Promise<void> {
+    const session = this.sessionManager.getGameSession(roomId);
+
+    if (!session) {
+      this.logger.warn(`Timer expired for missing session: phase=${phase} room=${roomId}`);
+
+      return;
+    }
+
+    if (session.currentPhase !== phase) {
+      this.logger.warn(
+        `Stale phase timeout ignored: expected=${session.currentPhase} received=${phase} room=${roomId}`,
+      );
+
+      return;
+    }
+
     switch (phase) {
       case 'ready':
         await this.phaseQuestion(roomId);
         break;
       case 'question':
-        this.handleQuestionTimeout(roomId);
+        await this.handleQuestionTimeout(roomId);
         break;
       case 'review':
         await this.transitionToNextRound(roomId);
         break;
-      default:
-        this.logger.warn(`Unknown phase timeout: ${phase as string} for room ${roomId}`);
     }
   }
 
@@ -433,7 +447,7 @@ export class RoundProgressionService {
   /**
    * 타임아웃 처리 (답안 미제출)
    */
-  private handleQuestionTimeout(roomId: string): void {
+  private async handleQuestionTimeout(roomId: string): Promise<void> {
     try {
       const session = this.sessionManager.getGameSession(roomId);
 
@@ -447,10 +461,10 @@ export class RoundProgressionService {
       }
 
       // 그레이딩으로 진행
-      void this.phaseGrading(roomId);
+      await this.phaseGrading(roomId);
     } catch (error) {
       this.logger.error(`Error in handleQuestionTimeout for room ${roomId}:`, error);
-      this.roundTimer.clearAllTimers(roomId);
+      await this.roundTimer.clearAllTimers(roomId);
     }
   }
 }

--- a/packages/backend/src/game/round-progression.service.ts
+++ b/packages/backend/src/game/round-progression.service.ts
@@ -34,13 +34,32 @@ export class RoundProgressionService {
    * 라운드 시퀀스 시작
    */
   startRoundSequence(roomId: string): void {
-    this.phaseReady(roomId);
+    void this.phaseReady(roomId);
+  }
+
+  /**
+   * BullMQ 워커에서 호출: 페이즈 타임아웃 처리
+   */
+  async handleTimerExpired(roomId: string, phase: 'ready' | 'question' | 'review'): Promise<void> {
+    switch (phase) {
+      case 'ready':
+        await this.phaseQuestion(roomId);
+        break;
+      case 'question':
+        this.handleQuestionTimeout(roomId);
+        break;
+      case 'review':
+        await this.transitionToNextRound(roomId);
+        break;
+      default:
+        this.logger.warn(`Unknown phase timeout: ${phase as string} for room ${roomId}`);
+    }
   }
 
   /**
    * Phase 1: Ready (준비 카운트다운)
    */
-  private phaseReady(roomId: string): void {
+  private async phaseReady(roomId: string): Promise<void> {
     try {
       this.sessionManager.setPhase(roomId, 'ready');
       const session = this.sessionManager.getGameSession(roomId);
@@ -56,10 +75,8 @@ export class RoundProgressionService {
         totalRounds: session.totalRounds,
       });
 
-      // 준비 카운트다운 시작
-      this.roundTimer.startReadyCountdown(roomId, ROUND_DURATIONS.READY, () => {
-        void this.phaseQuestion(roomId);
-      });
+      // 준비 카운트다운 시작 (BullMQ delayed job)
+      await this.roundTimer.startReadyCountdown(roomId, ROUND_DURATIONS.READY);
 
       // 틱 인터벌 시작
       this.roundTimer.startTickInterval(roomId, ROUND_DURATIONS.READY, (remainedSec) => {
@@ -67,7 +84,7 @@ export class RoundProgressionService {
       });
     } catch (error) {
       this.logger.error(`Error in phaseReady for room ${roomId}:`, error);
-      this.roundTimer.clearAllTimers(roomId);
+      await this.roundTimer.clearAllTimers(roomId);
     }
   }
 
@@ -107,10 +124,8 @@ export class RoundProgressionService {
         question: transformedQuestion,
       });
 
-      // 타이머 시작
-      this.roundTimer.startQuestionTimer(roomId, questionDuration, () => {
-        this.handleQuestionTimeout(roomId);
-      });
+      // 타이머 시작 (BullMQ delayed job)
+      await this.roundTimer.startQuestionTimer(roomId, questionDuration);
 
       // 틱 인터벌 시작
       this.roundTimer.startTickInterval(roomId, questionDuration, (remainedSec) => {
@@ -118,7 +133,7 @@ export class RoundProgressionService {
       });
     } catch (error) {
       this.logger.error(`Error in phaseQuestion for room ${roomId}:`, error);
-      this.roundTimer.clearAllTimers(roomId);
+      await this.roundTimer.clearAllTimers(roomId);
     }
   }
 
@@ -136,10 +151,10 @@ export class RoundProgressionService {
       await this.processGrading(roomId);
 
       // 결과 확인 단계로 이동
-      this.phaseReview(roomId);
+      await this.phaseReview(roomId);
     } catch (error) {
       this.logger.error(`Error in phaseGrading for room ${roomId}:`, error);
-      this.roundTimer.clearAllTimers(roomId);
+      await this.roundTimer.clearAllTimers(roomId);
     }
   }
 
@@ -227,7 +242,7 @@ export class RoundProgressionService {
   /**
    * Phase 4: Review (결과 확인)
    */
-  private phaseReview(roomId: string): void {
+  private async phaseReview(roomId: string): Promise<void> {
     try {
       this.sessionManager.setPhase(roomId, 'review');
       const session = this.sessionManager.getGameSession(roomId);
@@ -307,10 +322,8 @@ export class RoundProgressionService {
         },
       });
 
-      // 리뷰 타이머 시작
-      this.roundTimer.startReviewTimer(roomId, reviewDuration, () => {
-        void this.transitionToNextRound(roomId);
-      });
+      // 리뷰 타이머 시작 (BullMQ delayed job)
+      await this.roundTimer.startReviewTimer(roomId, reviewDuration);
 
       // 틱 인터벌 시작
       this.roundTimer.startTickInterval(roomId, reviewDuration, (remainedSec) => {
@@ -318,7 +331,7 @@ export class RoundProgressionService {
       });
     } catch (error) {
       this.logger.error(`Error in phaseReview for room ${roomId}:`, error);
-      this.roundTimer.clearAllTimers(roomId);
+      await this.roundTimer.clearAllTimers(roomId);
     }
   }
 
@@ -338,7 +351,7 @@ export class RoundProgressionService {
       }
     } catch (error) {
       this.logger.error(`Error in transitionToNextRound for room ${roomId}:`, error);
-      this.roundTimer.clearAllTimers(roomId);
+      await this.roundTimer.clearAllTimers(roomId);
     }
   }
 
@@ -375,10 +388,10 @@ export class RoundProgressionService {
 
       // 세션 정리
       this.sessionManager.deleteGameSession(roomId);
-      this.roundTimer.clearAllTimers(roomId);
+      await this.roundTimer.clearAllTimers(roomId);
     } catch (error) {
       this.logger.error(`Error in finishGame for room ${roomId}:`, error);
-      this.roundTimer.clearAllTimers(roomId);
+      await this.roundTimer.clearAllTimers(roomId);
     }
   }
 

--- a/packages/backend/src/game/round-timer.ts
+++ b/packages/backend/src/game/round-timer.ts
@@ -1,10 +1,8 @@
-import { Injectable } from '@nestjs/common';
-
-interface TimerSet {
-  readyTimer?: NodeJS.Timeout;
-  questionTimer?: NodeJS.Timeout;
-  reviewTimer?: NodeJS.Timeout;
-}
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { ROUND_TIMER_QUEUE } from './queues/queue.constants';
+import { RoundTimerJobData } from './workers/round-timer.worker';
 
 interface TickRoom {
   endAt: number;
@@ -14,29 +12,50 @@ interface TickRoom {
 
 @Injectable()
 export class RoundTimer {
-  private timers = new Map<string, TimerSet>();
+  private readonly logger = new Logger(RoundTimer.name);
   private tickRooms = new Map<string, TickRoom>();
   private globalTickInterval?: NodeJS.Timeout;
 
-  /**
-   * 준비 카운트다운 타이머 시작
-   */
-  startReadyCountdown(roomId: string, duration: number, callback: () => void): void {
-    this.startTimer(roomId, 'readyTimer', duration, callback);
+  constructor(@InjectQueue(ROUND_TIMER_QUEUE) private readonly queue: Queue<RoundTimerJobData>) {}
+
+  async startReadyCountdown(roomId: string, duration: number): Promise<void> {
+    await this.schedulePhaseTimeout(roomId, 'ready', duration);
+  }
+
+  async startQuestionTimer(roomId: string, duration: number): Promise<void> {
+    await this.schedulePhaseTimeout(roomId, 'question', duration);
+  }
+
+  async startReviewTimer(roomId: string, duration: number): Promise<void> {
+    await this.schedulePhaseTimeout(roomId, 'review', duration);
+  }
+
+  private async schedulePhaseTimeout(
+    roomId: string,
+    phase: 'ready' | 'question' | 'review',
+    duration: number,
+  ): Promise<void> {
+    const jobId = `phase:${phase}:${roomId}`;
+    // 이전 job 제거 후 추가 (동일 roomId 재스케줄 시 중복 방지)
+    await this.queue.remove(jobId);
+    await this.queue.add(
+      'phase-timeout',
+      { roomId, phase },
+      {
+        delay: duration * 1000,
+        jobId,
+        removeOnComplete: true,
+        removeOnFail: false,
+      },
+    );
+    this.logger.log(`[Timer] scheduled ${phase} timeout in ${duration}s for room=${roomId}`);
   }
 
   /**
-   * 문제 풀이 타이머 시작
-   */
-  startQuestionTimer(roomId: string, duration: number, onTimeout: () => void): void {
-    this.startTimer(roomId, 'questionTimer', duration, onTimeout);
-  }
-
-  /**
-   * 시간 동기화 틱 인터벌 시작 (전역 틱 방식)
+   * 시간 동기화 틱 인터벌 (클라이언트 UI 업데이트용)
    *
-   * 게임 시작 시 방을 등록하고, 각 라운드마다 endAt만 업데이트합니다.
-   * 방은 게임이 완전히 종료될 때까지 유지됩니다.
+   * 틱은 게임 진행에 영향을 주지 않으므로 in-process setInterval을 유지.
+   * 페이즈 전환은 BullMQ가 보장하므로 노드 크래시 시 틱이 멈춰도 게임은 정상 진행됨.
    */
   startTickInterval(
     roomId: string,
@@ -44,8 +63,6 @@ export class RoundTimer {
     onTick: (remainedSec: number) => void,
   ): void {
     const endAt = Date.now() + totalDuration * 1000;
-
-    // 방이 이미 존재하면 endAt과 onTick만 업데이트, 없으면 새로 생성
     const existingRoom = this.tickRooms.get(roomId);
 
     if (existingRoom) {
@@ -56,29 +73,19 @@ export class RoundTimer {
       this.tickRooms.set(roomId, { endAt, onTick, active: true });
     }
 
-    // 즉시 첫 틱 전송
     onTick(totalDuration);
 
-    // 전역 틱 인터벌이 없으면 시작
     if (!this.globalTickInterval) {
       this.startGlobalTick();
     }
   }
 
-  /**
-   * 전역 틱 인터벌 시작 (모든 방에 대해 1초마다 브로드캐스팅)
-   *
-   * 단일 setInterval로 모든 방의 타이머를 관리합니다.
-   * 방이 100개여도 setInterval은 1개만 사용됩니다.
-   */
   private startGlobalTick(): void {
     this.globalTickInterval = setInterval(() => {
       const now = Date.now();
       let hasActiveRoom = false;
 
-      // 모든 방을 순회하며 활성 상태인 방만 처리
       for (const room of this.tickRooms.values()) {
-        // 비활성 방은 스킵
         if (!room.active) {
           continue;
         }
@@ -87,13 +94,11 @@ export class RoundTimer {
         const remainedSec = Math.max(0, Math.ceil((room.endAt - now) / 1000));
         room.onTick(remainedSec);
 
-        // 현재 라운드 시간이 종료되면 비활성화 (다음 라운드에서 재활성화됨)
         if (remainedSec <= 0) {
           room.active = false;
         }
       }
 
-      // 활성 방이 없으면 전역 인터벌 정리 (새로운 라운드 시작 시 다시 생성됨)
       if (!hasActiveRoom) {
         clearInterval(this.globalTickInterval);
         this.globalTickInterval = undefined;
@@ -101,42 +106,6 @@ export class RoundTimer {
     }, 1000);
   }
 
-  /**
-   * 결과 확인 타이머 시작
-   */
-  startReviewTimer(roomId: string, duration: number, callback: () => void): void {
-    this.startTimer(roomId, 'reviewTimer', duration, callback);
-  }
-
-  /**
-   * 공통 타이머 시작 로직
-   */
-  private startTimer(
-    roomId: string,
-    timerKey: 'readyTimer' | 'questionTimer' | 'reviewTimer',
-    duration: number,
-    callback: () => void,
-  ): void {
-    this.clearTimer(roomId, timerKey);
-
-    const timer = setTimeout(() => {
-      callback();
-      this.clearTimer(roomId, timerKey);
-    }, duration * 1000);
-
-    this.getOrCreateTimerSet(roomId)[timerKey] = timer;
-  }
-
-  /**
-   * 문제 풀이 타이머만 정리
-   */
-  clearQuestionTimer(roomId: string): void {
-    this.clearTimer(roomId, 'questionTimer');
-  }
-
-  /**
-   * 틱 인터벌 정지 (방은 유지하고 비활성화만 함)
-   */
   clearTickInterval(roomId: string): void {
     const room = this.tickRooms.get(roomId);
 
@@ -145,61 +114,21 @@ export class RoundTimer {
     }
   }
 
-  /**
-   * 공통 타이머 정리 로직
-   */
-  private clearTimer(
-    roomId: string,
-    timerKey: 'readyTimer' | 'questionTimer' | 'reviewTimer',
-  ): void {
-    const timerSet = this.timers.get(roomId);
-
-    if (timerSet?.[timerKey]) {
-      clearTimeout(timerSet[timerKey]);
-      timerSet[timerKey] = undefined;
-    }
+  async clearQuestionTimer(roomId: string): Promise<void> {
+    await this.queue.remove(`phase:question:${roomId}`);
   }
 
-  /**
-   * 모든 타이머 정리 (게임 종료 시 호출)
-   */
-  clearAllTimers(roomId: string): void {
-    const timerSet = this.timers.get(roomId);
-
-    if (timerSet) {
-      if (timerSet.readyTimer) {
-        clearTimeout(timerSet.readyTimer);
-      }
-
-      if (timerSet.questionTimer) {
-        clearTimeout(timerSet.questionTimer);
-      }
-
-      if (timerSet.reviewTimer) {
-        clearTimeout(timerSet.reviewTimer);
-      }
-
-      this.timers.delete(roomId);
-    }
-
-    // 게임 종료이므로 tickRooms에서 방 완전히 제거
+  async clearAllTimers(roomId: string): Promise<void> {
+    await Promise.allSettled([
+      this.queue.remove(`phase:ready:${roomId}`),
+      this.queue.remove(`phase:question:${roomId}`),
+      this.queue.remove(`phase:review:${roomId}`),
+    ]);
     this.tickRooms.delete(roomId);
 
-    // 모든 방이 종료되면 전역 인터벌 정리
     if (this.tickRooms.size === 0 && this.globalTickInterval) {
       clearInterval(this.globalTickInterval);
       this.globalTickInterval = undefined;
     }
-  }
-
-  /**
-   * 타이머 세트 가져오기 또는 생성
-   */
-  private getOrCreateTimerSet(roomId: string): TimerSet {
-    if (!this.timers.has(roomId)) {
-      this.timers.set(roomId, {});
-    }
-
-    return this.timers.get(roomId);
   }
 }

--- a/packages/backend/src/game/workers/match-persistence.worker.ts
+++ b/packages/backend/src/game/workers/match-persistence.worker.ts
@@ -1,0 +1,22 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { MATCH_PERSISTENCE_QUEUE } from '../queues/queue.constants';
+import { MatchPersistenceJobData, MatchPersistenceService } from '../match-persistence.service';
+
+@Processor(MATCH_PERSISTENCE_QUEUE)
+export class MatchPersistenceWorker extends WorkerHost {
+  private readonly logger = new Logger(MatchPersistenceWorker.name);
+
+  constructor(private readonly matchPersistence: MatchPersistenceService) {
+    super();
+  }
+
+  async process(job: Job<MatchPersistenceJobData>): Promise<void> {
+    const { snapshot, finalResult } = job.data;
+    this.logger.log(
+      `매치 재시도 저장 - room=${snapshot.roomId} (attempt ${job.attemptsMade + 1}/${job.opts.attempts ?? 5})`,
+    );
+    await this.matchPersistence.saveMatchFromSnapshot(snapshot, finalResult);
+  }
+}

--- a/packages/backend/src/game/workers/round-timer.worker.ts
+++ b/packages/backend/src/game/workers/round-timer.worker.ts
@@ -1,0 +1,53 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { ROUND_TIMER_QUEUE } from '../queues/queue.constants';
+import { GameSessionManager } from '../game-session-manager';
+import { RoundProgressionService } from '../round-progression.service';
+import { GameCommandBus } from '../game-command-bus';
+
+export interface RoundTimerJobData {
+  roomId: string;
+  phase: 'ready' | 'question' | 'review';
+}
+
+@Processor(ROUND_TIMER_QUEUE)
+export class RoundTimerWorker extends WorkerHost {
+  private readonly logger = new Logger(RoundTimerWorker.name);
+
+  constructor(
+    private readonly sessionManager: GameSessionManager,
+    private readonly roundProgression: RoundProgressionService,
+    private readonly commandBus: GameCommandBus,
+  ) {
+    super();
+  }
+
+  async process(job: Job<RoundTimerJobData>): Promise<void> {
+    const { roomId, phase } = job.data;
+
+    // 이 인스턴스에 세션이 있으면 직접 처리
+    const session = this.sessionManager.getGameSession(roomId);
+
+    if (session) {
+      this.logger.log(`[Timer] ${phase} timeout: room=${roomId} (local)`);
+      await this.roundProgression.handleTimerExpired(roomId, phase);
+
+      return;
+    }
+
+    // 세션 보유 인스턴스로 포워딩
+    this.logger.log(`[Timer] ${phase} timeout: room=${roomId} (forwarding)`);
+    const response = await this.commandBus.forward({
+      type: 'phase_timeout',
+      roomId,
+      userId: '',
+      payload: { phase },
+    });
+
+    if (!response.ok) {
+      // 세션이 이미 종료된 경우 (정상 종료 후 stale job) — 오류가 아님
+      this.logger.warn(`[Timer] forward failed for ${phase}/${roomId}: ${response.error}`);
+    }
+  }
+}

--- a/packages/backend/test/match-persistence.service.spec.ts
+++ b/packages/backend/test/match-persistence.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DataSource, EntityManager, Repository } from 'typeorm';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { getQueueToken } from '@nestjs/bullmq';
 import { MatchPersistenceService } from '../src/game/match-persistence.service';
 import { GameSessionManager } from '../src/game/game-session-manager';
 import { QuizService } from '../src/quiz/quiz.service';
@@ -8,6 +9,7 @@ import { Match, Round, RoundAnswer } from '../src/match/entity';
 import { UserProblemBank } from '../src/problem-bank/entity';
 import { UserStatistics } from '../src/user/entity';
 import { GameSession } from '../src/game/interfaces/game.interfaces';
+import { MATCH_PERSISTENCE_QUEUE } from '../src/game/queues/queue.constants';
 
 describe('MatchPersistenceService', () => {
   let service: MatchPersistenceService;
@@ -59,6 +61,10 @@ describe('MatchPersistenceService', () => {
         {
           provide: QuizService,
           useValue: mockQuizService,
+        },
+        {
+          provide: getQueueToken(MATCH_PERSISTENCE_QUEUE),
+          useValue: { add: jest.fn() },
         },
       ],
     }).compile();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
 
   packages/backend:
     dependencies:
+      '@nestjs/bullmq':
+        specifier: ^11.0.4
+        version: 11.0.4(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22)(bullmq@5.76.0)
       '@nestjs/common':
         specifier: ^10.0.0
         version: 10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -81,6 +84,9 @@ importers:
       '@willsoto/nestjs-prometheus':
         specifier: ^6.0.2
         version: 6.0.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(prom-client@15.1.3)
+      bullmq:
+        specifier: ^5.76.0
+        version: 5.76.0
       compression:
         specifier: ^1.8.1
         version: 1.8.1
@@ -827,6 +833,49 @@ packages:
 
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@nestjs/bull-shared@11.0.4':
+    resolution: {integrity: sha512-VBJcDHSAzxQnpcDfA0kt9MTGUD1XZzfByV70su0W0eDCQ9aqIEBlzWRW21tv9FG9dIut22ysgDidshdjlnczLw==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+
+  '@nestjs/bullmq@11.0.4':
+    resolution: {integrity: sha512-wBzK9raAVG0/6NTMdvLGM4/FQ1lsB35/pYS8L6a0SDgkTiLpd7mAjQ8R692oMx5s7IjvgntaZOuTUrKYLNfIkA==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+      bullmq: ^3.0.0 || ^4.0.0 || ^5.0.0
 
   '@nestjs/cli@10.4.9':
     resolution: {integrity: sha512-s8qYd97bggqeK7Op3iD49X2MpFtW4LVNLAwXFkfbRxKME6IYT7X0muNTJ2+QfI8hpbNx9isWkrLWIp+g5FOhiA==}
@@ -2116,6 +2165,9 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  bullmq@5.76.0:
+    resolution: {integrity: sha512-gVknzNL7wr3tsDQEf/CL6tHpi++eOWqsLN/s0hETgQmPy6GFVv6aKUQ8yvrbdTbeorC+hbbsLdyqaPD2eLAGRA==}
+
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
@@ -2366,6 +2418,10 @@ packages:
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
+  cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2515,6 +2571,10 @@ packages:
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -3654,6 +3714,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
+
   magic-string@0.30.8:
     resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
     engines: {node: '>=12'}
@@ -3754,6 +3818,13 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.5:
+    resolution: {integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==}
+
   multer@2.0.2:
     resolution: {integrity: sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==}
     engines: {node: '>= 10.16.0'}
@@ -3811,6 +3882,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -4431,6 +4506,11 @@ packages:
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5836,6 +5916,38 @@ snapshots:
   '@lukeed/csprng@1.1.0': {}
 
   '@microsoft/tsdoc@0.15.1': {}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
+
+  '@nestjs/bull-shared@11.0.4(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22)':
+    dependencies:
+      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      tslib: 2.8.1
+
+  '@nestjs/bullmq@11.0.4(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22)(bullmq@5.76.0)':
+    dependencies:
+      '@nestjs/bull-shared': 11.0.4(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22)
+      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      bullmq: 5.76.0
+      tslib: 2.8.1
 
   '@nestjs/cli@10.4.9':
     dependencies:
@@ -7408,6 +7520,18 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bullmq@5.76.0:
+    dependencies:
+      cron-parser: 4.9.0
+      ioredis: 5.10.1
+      msgpackr: 1.11.5
+      node-abort-controller: 3.1.1
+      semver: 7.7.4
+      tslib: 2.8.1
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
@@ -7649,6 +7773,10 @@ snapshots:
 
   create-require@1.1.1: {}
 
+  cron-parser@4.9.0:
+    dependencies:
+      luxon: 3.7.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -7764,6 +7892,9 @@ snapshots:
   depd@2.0.0: {}
 
   destroy@1.2.0: {}
+
+  detect-libc@2.1.2:
+    optional: true
 
   detect-newline@3.1.0: {}
 
@@ -9328,6 +9459,8 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  luxon@3.7.2: {}
+
   magic-string@0.30.8:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -9401,6 +9534,22 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.5:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
   multer@2.0.2:
     dependencies:
       append-field: 1.0.0
@@ -9448,6 +9597,11 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-int64@0.4.0: {}
 
@@ -10032,6 +10186,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.3: {}
+
+  semver@7.7.4: {}
 
   send@0.19.2:
     dependencies:


### PR DESCRIPTION
## 📝 개요 (Description)

Redis 기반 분산 아키텍처 전환 이후에도 게임 타이머와 매치 결과 저장이 단일 노드에 묶여 있던 문제를 BullMQ로 해결했습니다.

**문제 1 — RoundTimer 노드 종속성**  
페이즈 전환(`ready → question`, `question → grading`, `review → 다음 라운드`)을 담당하는 setTimeout이 프로세스 메모리에만 존재했습니다. 게임을 시작한 노드가 크래시하면 타이머가 사라져 게임이 현재 페이즈에서 영구 정지됩니다.

**문제 2 — MatchPersistenceService in-process 재시도**  
매치 결과 DB 저장 실패 시 지수 백오프로 재시도하는 로직이 메모리 안에만 있었습니다. 재시도 도중 노드가 재시작되면 데이터가 유실됩니다(코드에 `데이터 유실 가능성 있음` 주석이 존재했습니다).

**변경 사항:**

- `RoundTimer`의 페이즈 전환을 BullMQ delayed job으로 교체. 결정론적 jobId(`phase:ready:{roomId}` 등)로 중복 실행 방지. job은 Redis에 저장되므로 노드 크래시 후 다른 인스턴스 워커가 이어받아 처리합니다.
- 로컬 세션이 없는 워커는 `GameCommandBus.forward('phase_timeout', ...)`으로 세션 보유 인스턴스에 라우팅합니다.
- `MatchPersistenceService`의 재시도를 BullMQ 큐로 교체. 1차 시도는 동기 경로로 즉시 실행(ELO 변화량 즉시 반환 유지). 실패 시 `SessionSnapshot`을 직렬화해 job payload로 Redis에 저장 → 노드가 재시작돼도 재시도 가능합니다.
- `GameCommand` 타입에 `phase_timeout` 추가. `GameGateway`에서 원격 타이머 만료 이벤트를 처리합니다.

## 🔗 관련 이슈 (Related Issues)

- Closes #276

## 🏷️ 작업 유형 (Type of Change)

- [ ] ✨ 기능 추가 (New Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] 🔧 설정 변경 및 기타 (Config & Other)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 컴파일/빌드 되나요?
- [x] 기존 테스트를 통과했나요? (새로운 테스트가 필요하다면 추가했나요?)
- [x] 스스로 코드를 리뷰했나요? (Self-review)
- [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
- [ ] 문서(README 등)에 변경 사항을 업데이트했나요?

## 🎸 기타 (Etc)

- tick interval(`round:tick` 이벤트)은 in-process setInterval을 유지합니다. 틱은 게임 진행 로직에 영향을 주지 않아 노드 크래시 시 틱이 멈춰도 BullMQ가 페이즈 전환을 보장하므로 게임은 정상 종료됩니다.
- DB 저장 1차 실패 시 `tierPointChange: 0`으로 `match:end`를 발송합니다. BullMQ 재시도로 데이터는 보존되지만 클라이언트에 ELO 변화량을 사후 통보하는 흐름은 없습니다.
- `removeOnFail: false` 설정으로 최종 실패 job이 Redis에 보존돼 수동 확인이 가능합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Infrastructure Improvements**
  * 게임 타임아웃 처리 신뢰성 향상
  * 매치 데이터 저장 재시도 메커니즘 개선
  * 백그라운드 작업 처리 시스템 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->