### PR TITLE
[FIX] GameSession 인메모리 Map 누수 방어

### DIFF
--- a/packages/backend/src/game/game-session-manager.ts
+++ b/packages/backend/src/game/game-session-manager.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/nestjs';
 import { UserInfo } from '../user/interfaces';
 import { Question as QuestionEntity } from '../quiz/entity';
 import { MetricsService } from '../metrics';
+import { RoundTimer } from './round-timer';
 import {
   GameSession,
   GradingInput,
@@ -24,11 +25,16 @@ export class GameSessionManager implements OnModuleInit, OnModuleDestroy {
   private gameSessions = new Map<string, GameSession>();
   private sweepInterval: NodeJS.Timeout | null = null;
 
-  constructor(private readonly metricsService: MetricsService) {}
+  constructor(
+    private readonly metricsService: MetricsService,
+    private readonly roundTimer: RoundTimer,
+  ) {}
 
   onModuleInit(): void {
     this.sweepInterval = setInterval(() => {
-      this.sweepStaleSessions();
+      this.sweepStaleSessions().catch((err) => {
+        this.logger.error('sweepStaleSessions failed', err);
+      });
     }, SWEEP_INTERVAL_MS);
   }
 
@@ -139,9 +145,11 @@ export class GameSessionManager implements OnModuleInit, OnModuleDestroy {
   /**
    * Idle sweeper — SESSION_STALE_MS 이상 활동 없는 세션 일괄 정리.
    * catch 블록 누락·비정상 종료 경로에서 남은 좀비 세션의 2차 방어선.
-   * 회수된 세션 수는 game_session_leak_recovered_total 메트릭에 기록.
+   *
+   * 정리 책임은 단일 경로(deleteGameSession + roundTimer.clearAllTimers)로 통합한다.
+   * 회수된 세션 수는 game_session_leak_recovered_total{reason="idle"}에 기록.
    */
-  sweepStaleSessions(): number {
+  async sweepStaleSessions(): Promise<number> {
     const now = Date.now();
     const staleRoomIds: string[] = [];
 
@@ -150,6 +158,8 @@ export class GameSessionManager implements OnModuleInit, OnModuleDestroy {
         staleRoomIds.push(roomId);
       }
     }
+
+    let reclaimed = 0;
 
     for (const roomId of staleRoomIds) {
       const session = this.gameSessions.get(roomId);
@@ -172,12 +182,28 @@ export class GameSessionManager implements OnModuleInit, OnModuleDestroy {
         extra: { ageMs, idleMs },
       });
 
-      this.gameSessions.delete(roomId);
-      this.metricsService.decrementActiveGames();
+      const deleted = this.deleteGameSession(roomId);
+
+      if (!deleted) {
+        continue;
+      }
+
+      // BullMQ 지연 잡(phase:*:roomId)이 큐에 남지 않도록 함께 정리.
+      // 실패해도 다음 세션 정리는 계속 진행.
+      try {
+        await this.roundTimer.clearAllTimers(roomId);
+      } catch (err) {
+        this.logger.error(`clearAllTimers failed during sweep for room ${roomId}`, err);
+        Sentry.captureException(err, {
+          tags: { roomId, phase: session.currentPhase, component: 'session-sweeper' },
+        });
+      }
+
       this.metricsService.recordGameSessionLeakRecovered('idle');
+      reclaimed++;
     }
 
-    return staleRoomIds.length;
+    return reclaimed;
   }
 
   getGameSession(roomId: string): GameSession | null {

--- a/packages/backend/src/game/game-session-manager.ts
+++ b/packages/backend/src/game/game-session-manager.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
 import { UserInfo } from '../user/interfaces';
 import { Question as QuestionEntity } from '../quiz/entity';
 import { MetricsService } from '../metrics';
@@ -11,11 +12,32 @@ import {
   Submission,
 } from './interfaces/game.interfaces';
 
+// Idle sweeper 설정
+// - 주기: 5분마다 검사
+// - stale 기준: 마지막 활동으로부터 30분 경과 (게임 1판 최대 ~5분 고려 시 여유)
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+const SESSION_STALE_MS = 30 * 60 * 1000;
+
 @Injectable()
-export class GameSessionManager {
+export class GameSessionManager implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(GameSessionManager.name);
   private gameSessions = new Map<string, GameSession>();
+  private sweepInterval: NodeJS.Timeout | null = null;
 
   constructor(private readonly metricsService: MetricsService) {}
+
+  onModuleInit(): void {
+    this.sweepInterval = setInterval(() => {
+      this.sweepStaleSessions();
+    }, SWEEP_INTERVAL_MS);
+  }
+
+  onModuleDestroy(): void {
+    if (this.sweepInterval) {
+      clearInterval(this.sweepInterval);
+      this.sweepInterval = null;
+    }
+  }
 
   /**
    * socketId로 userId 조회 (게임 세션에서)
@@ -48,9 +70,11 @@ export class GameSessionManager {
   }
 
   /**
-   * 게임 세션에서 연결 해제 처리
+   * socketId로부터 (userId, roomId)만 조회.
+   * 실제 세션 정리는 호출자가 deleteGameSession을 별도로 호출해야 한다.
+   * 이전 이름(disconnectFromGame)은 cleanup을 수행한다고 오해하기 쉬워 교정.
    */
-  disconnectFromGame(socketId: string): { userId?: string; roomId?: string } {
+  getDisconnectInfo(socketId: string): { userId?: string; roomId?: string } {
     const roomId = this.getRoomBySocketId(socketId);
     const userId = this.getUserIdBySocketId(socketId);
 
@@ -78,6 +102,7 @@ export class GameSessionManager {
       throw new Error(`이미 존재하는 게임 세션입니다: ${roomId}`);
     }
 
+    const now = Date.now();
     const session: GameSession = {
       roomId,
       player1Id,
@@ -92,13 +117,67 @@ export class GameSessionManager {
       totalRounds,
       rounds: new Map(),
       currentPhase: 'ready',
-      currentPhaseStartTime: Date.now(),
+      currentPhaseStartTime: now,
+      createdAt: now,
+      lastActivityAt: now,
     };
 
     this.gameSessions.set(roomId, session);
     this.metricsService.incrementActiveGames();
 
     return session;
+  }
+
+  /**
+   * 세션 활동 시각 갱신. phase 전환·답안 제출 등 상태 변경 시점에 호출.
+   * idle sweeper가 이 값을 기준으로 stale 세션을 판정한다.
+   */
+  private touchSession(session: GameSession): void {
+    session.lastActivityAt = Date.now();
+  }
+
+  /**
+   * Idle sweeper — SESSION_STALE_MS 이상 활동 없는 세션 일괄 정리.
+   * catch 블록 누락·비정상 종료 경로에서 남은 좀비 세션의 2차 방어선.
+   * 회수된 세션 수는 game_session_leak_recovered_total 메트릭에 기록.
+   */
+  sweepStaleSessions(): number {
+    const now = Date.now();
+    const staleRoomIds: string[] = [];
+
+    for (const [roomId, session] of this.gameSessions.entries()) {
+      if (now - session.lastActivityAt >= SESSION_STALE_MS) {
+        staleRoomIds.push(roomId);
+      }
+    }
+
+    for (const roomId of staleRoomIds) {
+      const session = this.gameSessions.get(roomId);
+
+      if (!session) {
+        continue;
+      }
+
+      const ageMs = now - session.createdAt;
+      const idleMs = now - session.lastActivityAt;
+
+      this.logger.warn(
+        `Stale session reclaimed: roomId=${roomId} age=${Math.round(ageMs / 1000)}s idle=${Math.round(
+          idleMs / 1000,
+        )}s phase=${session.currentPhase}`,
+      );
+      Sentry.captureMessage('Stale game session reclaimed', {
+        level: 'warning',
+        tags: { roomId, phase: session.currentPhase },
+        extra: { ageMs, idleMs },
+      });
+
+      this.gameSessions.delete(roomId);
+      this.metricsService.decrementActiveGames();
+      this.metricsService.recordGameSessionLeakRecovered('idle');
+    }
+
+    return staleRoomIds.length;
   }
 
   getGameSession(roomId: string): GameSession | null {
@@ -137,6 +216,7 @@ export class GameSessionManager {
 
     session.rounds.set(nextRoundNumber, roundData);
     session.currentRound = nextRoundNumber;
+    this.touchSession(session);
 
     return roundData;
   }
@@ -184,6 +264,7 @@ export class GameSessionManager {
     };
 
     round.submissions[playerId] = submission;
+    this.touchSession(session);
 
     return submission;
   }
@@ -221,6 +302,7 @@ export class GameSessionManager {
 
     round.result = result;
     round.status = 'completed';
+    this.touchSession(session);
   }
 
   getRoundResult(roomId: string, roundNumber?: number): RoundResult | null {
@@ -294,6 +376,7 @@ export class GameSessionManager {
     const session = this.getGameSessionOrThrow(roomId);
     session.currentPhase = phase;
     session.currentPhaseStartTime = Date.now();
+    this.touchSession(session);
   }
 
   getPhase(roomId: string): RoundPhase {

--- a/packages/backend/src/game/game.gateway.ts
+++ b/packages/backend/src/game/game.gateway.ts
@@ -190,7 +190,7 @@ export class GameGateway implements OnGatewayDisconnect, OnGatewayInit, OnModule
   }
 
   async handleDisconnect(client: Socket): Promise<void> {
-    const disconnectInfo = this.sessionManager.disconnectFromGame(client.id);
+    const disconnectInfo = this.sessionManager.getDisconnectInfo(client.id);
 
     // 게임 중 연결 끊김 처리
     if (disconnectInfo.roomId && disconnectInfo.userId) {

--- a/packages/backend/src/game/interfaces/game.interfaces.ts
+++ b/packages/backend/src/game/interfaces/game.interfaces.ts
@@ -20,6 +20,9 @@ export interface GameSession {
   rounds: Map<number, RoundData>;
   currentPhase: 'ready' | 'question' | 'grading' | 'review' | 'finished';
   currentPhaseStartTime: number;
+  // 세션 수명 감사용. idle sweeper가 lastActivityAt 기준으로 stale 판정.
+  createdAt: number;
+  lastActivityAt: number;
 }
 
 export type RoundStatus = 'waiting' | 'in_progress' | 'completed';

--- a/packages/backend/src/game/round-progression.service.ts
+++ b/packages/backend/src/game/round-progression.service.ts
@@ -1,9 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
 import { Server } from 'socket.io';
 import { RoundTimer } from './round-timer';
 import { QuizService } from '../quiz/quiz.service';
 import { GameSessionManager } from './game-session-manager';
 import { MatchPersistenceService } from './match-persistence.service';
+import { MetricsService } from '../metrics';
 import { getValidQuestionType, ROUND_DURATIONS } from './round-timer.constants';
 import { SPEED_BONUS } from '../quiz/quiz.constants';
 import { transformQuestionForClient } from './transformers/question.transformer';
@@ -21,7 +23,32 @@ export class RoundProgressionService {
     private readonly quizService: QuizService,
     private readonly sessionManager: GameSessionManager,
     private readonly matchPersistence: MatchPersistenceService,
+    private readonly metricsService: MetricsService,
   ) {}
+
+  /**
+   * 라운드 진행 중 에러 발생 시 일관된 종료 처리.
+   * 1) Sentry에 context 태그 포함해 전송
+   * 2) 타이머 전체 정리
+   * 3) 게임 세션 삭제 (메모리 누수 방지)
+   * 4) 누수 회수 메트릭 기록
+   *
+   * 기존에는 catch 블록이 타이머만 정리하고 세션은 Map에 남아 좀비 상태가 됐음.
+   */
+  private async abortGameOnError(roomId: string, phase: string, error: unknown): Promise<void> {
+    this.logger.error(`Error in ${phase} for room ${roomId}:`, error);
+    Sentry.captureException(error, {
+      tags: { roomId, phase, component: 'round-progression' },
+    });
+
+    await this.roundTimer.clearAllTimers(roomId);
+
+    const deleted = this.sessionManager.deleteGameSession(roomId);
+
+    if (deleted) {
+      this.metricsService.recordGameSessionLeakRecovered('catch_error');
+    }
+  }
 
   /**
    * WebSocket Server 설정 (GameGateway에서 호출)
@@ -97,8 +124,7 @@ export class RoundProgressionService {
         this.server.to(roomId).emit('round:tick', { remainedSec });
       });
     } catch (error) {
-      this.logger.error(`Error in phaseReady for room ${roomId}:`, error);
-      await this.roundTimer.clearAllTimers(roomId);
+      await this.abortGameOnError(roomId, 'phaseReady', error);
     }
   }
 
@@ -146,8 +172,7 @@ export class RoundProgressionService {
         this.server.to(roomId).emit('round:tick', { remainedSec });
       });
     } catch (error) {
-      this.logger.error(`Error in phaseQuestion for room ${roomId}:`, error);
-      await this.roundTimer.clearAllTimers(roomId);
+      await this.abortGameOnError(roomId, 'phaseQuestion', error);
     }
   }
 
@@ -167,8 +192,7 @@ export class RoundProgressionService {
       // 결과 확인 단계로 이동
       await this.phaseReview(roomId);
     } catch (error) {
-      this.logger.error(`Error in phaseGrading for room ${roomId}:`, error);
-      await this.roundTimer.clearAllTimers(roomId);
+      await this.abortGameOnError(roomId, 'phaseGrading', error);
     }
   }
 
@@ -344,8 +368,7 @@ export class RoundProgressionService {
         this.server.to(roomId).emit('round:tick', { remainedSec });
       });
     } catch (error) {
-      this.logger.error(`Error in phaseReview for room ${roomId}:`, error);
-      await this.roundTimer.clearAllTimers(roomId);
+      await this.abortGameOnError(roomId, 'phaseReview', error);
     }
   }
 
@@ -364,13 +387,15 @@ export class RoundProgressionService {
         this.startRoundSequence(roomId);
       }
     } catch (error) {
-      this.logger.error(`Error in transitionToNextRound for room ${roomId}:`, error);
-      await this.roundTimer.clearAllTimers(roomId);
+      await this.abortGameOnError(roomId, 'transitionToNextRound', error);
     }
   }
 
   /**
    * 게임 종료 처리
+   *
+   * finally 블록에서 세션/타이머를 일관되게 정리한다.
+   * try 블록 안에서 매치 저장이 throw되더라도 세션이 Map에 남지 않는다.
    */
   private async finishGame(roomId: string): Promise<void> {
     try {
@@ -399,12 +424,14 @@ export class RoundProgressionService {
         },
         tierPointChange: eloChanges?.player2Change ?? 0,
       });
-
-      // 세션 정리
-      this.sessionManager.deleteGameSession(roomId);
-      await this.roundTimer.clearAllTimers(roomId);
     } catch (error) {
       this.logger.error(`Error in finishGame for room ${roomId}:`, error);
+      Sentry.captureException(error, {
+        tags: { roomId, phase: 'finishGame', component: 'round-progression' },
+      });
+    } finally {
+      // 정상/에러 어느 경로든 보장되는 cleanup
+      this.sessionManager.deleteGameSession(roomId);
       await this.roundTimer.clearAllTimers(roomId);
     }
   }
@@ -463,8 +490,7 @@ export class RoundProgressionService {
       // 그레이딩으로 진행
       await this.phaseGrading(roomId);
     } catch (error) {
-      this.logger.error(`Error in handleQuestionTimeout for room ${roomId}:`, error);
-      await this.roundTimer.clearAllTimers(roomId);
+      await this.abortGameOnError(roomId, 'handleQuestionTimeout', error);
     }
   }
 }

--- a/packages/backend/src/metrics/metrics.module.ts
+++ b/packages/backend/src/metrics/metrics.module.ts
@@ -66,6 +66,13 @@ import { HttpMetricsInterceptor } from './http-metrics.interceptor';
       buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1],
     }),
 
+    // Idle sweeper가 회수한 누수 세션 수 (catch 블록 누락·비정상 종료 경로 감지)
+    makeCounterProvider({
+      name: 'game_session_leak_recovered_total',
+      help: 'Number of stale game sessions cleaned up by the idle sweeper',
+      labelNames: ['reason'],
+    }),
+
     MetricsService,
     HttpMetricsInterceptor,
   ],

--- a/packages/backend/src/metrics/metrics.module.ts
+++ b/packages/backend/src/metrics/metrics.module.ts
@@ -66,10 +66,12 @@ import { HttpMetricsInterceptor } from './http-metrics.interceptor';
       buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1],
     }),
 
-    // Idle sweeper가 회수한 누수 세션 수 (catch 블록 누락·비정상 종료 경로 감지)
+    // 누수 회수 세션 수 (라벨로 회수 경로 구분)
+    //   reason=idle        — 주기적 idle sweeper가 stale 판정해 정리한 세션
+    //   reason=catch_error — RoundProgressionService catch 헬퍼가 에러 경로에서 정리한 세션
     makeCounterProvider({
       name: 'game_session_leak_recovered_total',
-      help: 'Number of stale game sessions cleaned up by the idle sweeper',
+      help: 'Number of leaked game sessions reclaimed (reason=idle: periodic sweeper, reason=catch_error: error-path cleanup in round progression)',
       labelNames: ['reason'],
     }),
 

--- a/packages/backend/src/metrics/metrics.service.ts
+++ b/packages/backend/src/metrics/metrics.service.ts
@@ -90,7 +90,9 @@ export class MetricsService {
     this.gameCommandForwardLatency.observe(durationSeconds);
   }
 
-  // Idle sweeper가 회수한 누수 세션 기록
+  // 회수된 누수 세션 기록.
+  //   reason='idle'        — 주기적 idle sweeper가 정리
+  //   reason='catch_error' — RoundProgressionService catch 헬퍼가 에러 경로에서 정리
   recordGameSessionLeakRecovered(reason: 'idle' | 'catch_error'): void {
     this.gameSessionLeakRecovered.inc({ reason });
   }

--- a/packages/backend/src/metrics/metrics.service.ts
+++ b/packages/backend/src/metrics/metrics.service.ts
@@ -33,6 +33,9 @@ export class MetricsService {
 
     @InjectMetric('game_command_forward_latency_seconds')
     public readonly gameCommandForwardLatency: Histogram<string>,
+
+    @InjectMetric('game_session_leak_recovered_total')
+    public readonly gameSessionLeakRecovered: Counter<string>,
   ) {}
 
   // HTTP 메트릭 기록
@@ -85,6 +88,11 @@ export class MetricsService {
   // 게임 커맨드 포워딩 지연 시간 기록
   recordGameCommandForwardLatency(durationSeconds: number): void {
     this.gameCommandForwardLatency.observe(durationSeconds);
+  }
+
+  // Idle sweeper가 회수한 누수 세션 기록
+  recordGameSessionLeakRecovered(reason: 'idle' | 'catch_error'): void {
+    this.gameSessionLeakRecovered.inc({ reason });
   }
 
   // 경로 정규화 (동적 파라미터 제거)

--- a/packages/backend/test/game-session-manager.spec.ts
+++ b/packages/backend/test/game-session-manager.spec.ts
@@ -1,9 +1,12 @@
 import { GameSessionManager } from '../src/game/game-session-manager';
 import { UserInfo } from '../src/user/interfaces';
 import { Question as QuestionEntity } from '../src/quiz/entity';
+import { RoundTimer } from '../src/game/round-timer';
 
 describe('GameSessionManager - Game Session Management', () => {
   let sessionManager: GameSessionManager;
+  let mockMetricsService: any;
+  let mockRoundTimer: any;
 
   const mockUserInfo1: UserInfo = {
     nickname: 'Player1',
@@ -36,17 +39,26 @@ describe('GameSessionManager - Game Session Management', () => {
   } as any;
 
   beforeEach(() => {
-    const mockMetricsService = {
+    // sweeper의 setInterval을 가짜 타이머로 통제 — 라이프사이클(onModuleInit/Destroy)이
+    // 실제로 인터벌을 등록·해제하는지 검증 가능하게 한다.
+    jest.useFakeTimers();
+
+    mockMetricsService = {
       incrementActiveGames: jest.fn(),
       decrementActiveGames: jest.fn(),
       recordGameSessionLeakRecovered: jest.fn(),
-    } as any;
-    sessionManager = new GameSessionManager(mockMetricsService);
+    };
+    mockRoundTimer = {
+      clearAllTimers: jest.fn().mockResolvedValue(undefined),
+    } as unknown as RoundTimer;
+    sessionManager = new GameSessionManager(mockMetricsService, mockRoundTimer);
+    // 직접 인스턴스화는 NestJS 라이프사이클을 트리거하지 않으므로 명시적으로 호출.
+    sessionManager.onModuleInit();
   });
 
   afterEach(() => {
-    // setInterval 기반 sweeper가 테스트 런타임에 떠있지 않도록 정리
     sessionManager.onModuleDestroy();
+    jest.useRealTimers();
   });
 
   describe('createGameSession', () => {
@@ -660,14 +672,15 @@ describe('GameSessionManager - Game Session Management', () => {
       );
     });
 
-    it('stale 기준(30분) 이하 세션은 남아있어야 함', () => {
-      const cleaned = sessionManager.sweepStaleSessions();
+    it('stale 기준(30분) 이하 세션은 남아있어야 함', async () => {
+      const cleaned = await sessionManager.sweepStaleSessions();
 
       expect(cleaned).toBe(0);
       expect(sessionManager.getGameSession('room-stale')).not.toBeNull();
+      expect(mockRoundTimer.clearAllTimers).not.toHaveBeenCalled();
     });
 
-    it('lastActivityAt이 31분 이상 경과한 세션은 정리되어야 함', () => {
+    it('lastActivityAt이 31분 이상 경과한 세션은 정리되어야 함', async () => {
       const session = sessionManager.getGameSession('room-stale');
 
       if (!session) throw new Error('expected session');
@@ -675,10 +688,101 @@ describe('GameSessionManager - Game Session Management', () => {
       // 31분 전으로 인위적 조작
       session.lastActivityAt = Date.now() - 31 * 60 * 1000;
 
-      const cleaned = sessionManager.sweepStaleSessions();
+      const cleaned = await sessionManager.sweepStaleSessions();
 
       expect(cleaned).toBe(1);
       expect(sessionManager.getGameSession('room-stale')).toBeNull();
+    });
+
+    it('stale 세션 회수 시 deleteGameSession 단일 경로를 통과해야 함 (decrementActiveGames 호출)', async () => {
+      const session = sessionManager.getGameSession('room-stale');
+
+      if (!session) throw new Error('expected session');
+
+      session.lastActivityAt = Date.now() - 31 * 60 * 1000;
+
+      await sessionManager.sweepStaleSessions();
+
+      expect(mockMetricsService.decrementActiveGames).toHaveBeenCalledTimes(1);
+      expect(mockMetricsService.recordGameSessionLeakRecovered).toHaveBeenCalledWith('idle');
+    });
+
+    it('stale 세션 회수 시 BullMQ 지연 잡까지 함께 정리해야 함 (clearAllTimers 호출)', async () => {
+      const session = sessionManager.getGameSession('room-stale');
+
+      if (!session) throw new Error('expected session');
+
+      session.lastActivityAt = Date.now() - 31 * 60 * 1000;
+
+      await sessionManager.sweepStaleSessions();
+
+      expect(mockRoundTimer.clearAllTimers).toHaveBeenCalledWith('room-stale');
+    });
+
+    it('clearAllTimers가 throw해도 메트릭은 기록되고 다른 세션 회수가 계속되어야 함', async () => {
+      sessionManager.createGameSession(
+        'room-stale-2',
+        'user3',
+        'socket3',
+        mockUserInfo1,
+        'user4',
+        'socket4',
+        mockUserInfo2,
+      );
+
+      const s1 = sessionManager.getGameSession('room-stale');
+      const s2 = sessionManager.getGameSession('room-stale-2');
+
+      if (!s1 || !s2) throw new Error('expected sessions');
+
+      s1.lastActivityAt = Date.now() - 31 * 60 * 1000;
+      s2.lastActivityAt = Date.now() - 31 * 60 * 1000;
+
+      mockRoundTimer.clearAllTimers.mockRejectedValueOnce(new Error('queue down'));
+
+      const cleaned = await sessionManager.sweepStaleSessions();
+
+      expect(cleaned).toBe(2);
+      expect(sessionManager.getGameSession('room-stale')).toBeNull();
+      expect(sessionManager.getGameSession('room-stale-2')).toBeNull();
+      expect(mockMetricsService.recordGameSessionLeakRecovered).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('sweeper lifecycle', () => {
+    it('onModuleInit이 setInterval을 등록하고 onModuleDestroy가 해제해야 함', () => {
+      // beforeEach에서 이미 onModuleInit 호출됨 — 인터벌 1개 등록 상태
+      expect(jest.getTimerCount()).toBe(1);
+
+      sessionManager.onModuleDestroy();
+
+      expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it('인터벌 콜백이 발화되면 sweepStaleSessions가 실행되어야 함', async () => {
+      sessionManager.createGameSession(
+        'room-tick',
+        'user1',
+        'socket1',
+        mockUserInfo1,
+        'user2',
+        'socket2',
+        mockUserInfo2,
+      );
+
+      const session = sessionManager.getGameSession('room-tick');
+
+      if (!session) throw new Error('expected session');
+
+      session.lastActivityAt = Date.now() - 31 * 60 * 1000;
+
+      // 5분 진행 → sweep interval 콜백 발화
+      jest.advanceTimersByTime(5 * 60 * 1000);
+      // setInterval 콜백 안의 await this.sweepStaleSessions()의 마이크로태스크 처리
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockRoundTimer.clearAllTimers).toHaveBeenCalledWith('room-tick');
     });
   });
 });

--- a/packages/backend/test/game-session-manager.spec.ts
+++ b/packages/backend/test/game-session-manager.spec.ts
@@ -39,8 +39,14 @@ describe('GameSessionManager - Game Session Management', () => {
     const mockMetricsService = {
       incrementActiveGames: jest.fn(),
       decrementActiveGames: jest.fn(),
+      recordGameSessionLeakRecovered: jest.fn(),
     } as any;
     sessionManager = new GameSessionManager(mockMetricsService);
+  });
+
+  afterEach(() => {
+    // setInterval 기반 sweeper가 테스트 런타임에 떠있지 않도록 정리
+    sessionManager.onModuleDestroy();
   });
 
   describe('createGameSession', () => {
@@ -613,7 +619,7 @@ describe('GameSessionManager - Game Session Management', () => {
     });
   });
 
-  describe('disconnectFromGame', () => {
+  describe('getDisconnectInfo', () => {
     beforeEach(() => {
       sessionManager.createGameSession(
         'room-1',
@@ -627,17 +633,52 @@ describe('GameSessionManager - Game Session Management', () => {
     });
 
     it('socketId로 연결 해제 정보를 반환해야 함', () => {
-      const disconnectInfo = sessionManager.disconnectFromGame('socket1');
+      const disconnectInfo = sessionManager.getDisconnectInfo('socket1');
 
       expect(disconnectInfo.userId).toBe('user1');
       expect(disconnectInfo.roomId).toBe('room-1');
     });
 
     it('등록되지 않은 socketId의 경우 undefined를 반환해야 함', () => {
-      const disconnectInfo = sessionManager.disconnectFromGame('non-existent');
+      const disconnectInfo = sessionManager.getDisconnectInfo('non-existent');
 
       expect(disconnectInfo.userId).toBeUndefined();
       expect(disconnectInfo.roomId).toBeUndefined();
+    });
+  });
+
+  describe('sweepStaleSessions', () => {
+    beforeEach(() => {
+      sessionManager.createGameSession(
+        'room-stale',
+        'user1',
+        'socket1',
+        mockUserInfo1,
+        'user2',
+        'socket2',
+        mockUserInfo2,
+      );
+    });
+
+    it('stale 기준(30분) 이하 세션은 남아있어야 함', () => {
+      const cleaned = sessionManager.sweepStaleSessions();
+
+      expect(cleaned).toBe(0);
+      expect(sessionManager.getGameSession('room-stale')).not.toBeNull();
+    });
+
+    it('lastActivityAt이 31분 이상 경과한 세션은 정리되어야 함', () => {
+      const session = sessionManager.getGameSession('room-stale');
+
+      if (!session) throw new Error('expected session');
+
+      // 31분 전으로 인위적 조작
+      session.lastActivityAt = Date.now() - 31 * 60 * 1000;
+
+      const cleaned = sessionManager.sweepStaleSessions();
+
+      expect(cleaned).toBe(1);
+      expect(sessionManager.getGameSession('room-stale')).toBeNull();
     });
   });
 });

--- a/packages/backend/test/match-persistence.service.spec.ts
+++ b/packages/backend/test/match-persistence.service.spec.ts
@@ -100,6 +100,8 @@ describe('MatchPersistenceService', () => {
       rounds: new Map(),
       currentPhase: 'finished',
       currentPhaseStartTime: Date.now(),
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
     };
 
     const finalResult = {

--- a/packages/backend/test/round-progression.service.spec.ts
+++ b/packages/backend/test/round-progression.service.spec.ts
@@ -361,4 +361,66 @@ describe('RoundProgressionService - AI Score Weighted Grading Logic', () => {
       expect(SPEED_BONUS).toBe(5);
     });
   });
+
+  // 세션 누수 regression guard
+  describe('Leak Regression — catch 경로에서 세션 정리 보장', () => {
+    const roomId = 'leak-test-room';
+    const player1Id = 'p1';
+    const player2Id = 'p2';
+
+    beforeEach(() => {
+      sessionManager.createGameSession(
+        roomId,
+        player1Id,
+        'socket1',
+        { nickname: 'P1', profileImage: null, tier: 'gold', tierPoint: 1500, exp_point: 1500 },
+        player2Id,
+        'socket2',
+        { nickname: 'P2', profileImage: null, tier: 'silver', tierPoint: 1200, exp_point: 1200 },
+      );
+      sessionManager.startNextRound(roomId);
+      // 서버 객체 주입 (emit 호출이 throw되지 않도록 최소 stub)
+      (roundProgressionService as any).server = {
+        to: jest.fn().mockReturnValue({ emit: jest.fn() }),
+      };
+    });
+
+    it('finishGame에서 DB 저장 실패 시에도 세션이 정리되어야 함', async () => {
+      mockMatchPersistence.saveMatchToDatabase.mockRejectedValue(new Error('DB connection lost'));
+
+      // finishGame은 private이라 any 캐스팅
+      await (roundProgressionService as any).finishGame(roomId);
+
+      expect(sessionManager.getGameSession(roomId)).toBeNull();
+    });
+
+    it('phaseGrading에서 Clova API 타임아웃 시에도 세션이 정리되어야 함', async () => {
+      const mockQuestion: QuestionEntity = {
+        id: 99,
+        questionType: 'short',
+        difficulty: 1,
+        content: 'Q',
+        correctAnswer: 'A',
+      } as QuestionEntity;
+      sessionManager.setQuestion(roomId, mockQuestion);
+      sessionManager.submitAnswer(roomId, player1Id, 'a');
+      sessionManager.submitAnswer(roomId, player2Id, 'b');
+
+      // Clova API 장애 시뮬레이션
+      mockQuizService.gradeQuestion.mockRejectedValue(new Error('Clova timeout'));
+
+      await roundProgressionService.phaseGrading(roomId);
+
+      expect(sessionManager.getGameSession(roomId)).toBeNull();
+      expect(mockMetricsService.recordGameSessionLeakRecovered).toHaveBeenCalledWith('catch_error');
+    });
+
+    it('catch 경로에서 clearAllTimers도 반드시 호출되어야 함', async () => {
+      mockMatchPersistence.saveMatchToDatabase.mockRejectedValue(new Error('DB down'));
+
+      await (roundProgressionService as any).finishGame(roomId);
+
+      expect(mockRoundTimer.clearAllTimers).toHaveBeenCalledWith(roomId);
+    });
+  });
 });

--- a/packages/backend/test/round-progression.service.spec.ts
+++ b/packages/backend/test/round-progression.service.spec.ts
@@ -42,6 +42,7 @@ describe('RoundProgressionService - AI Score Weighted Grading Logic', () => {
   const mockMetricsService = {
     incrementActiveGames: jest.fn(),
     decrementActiveGames: jest.fn(),
+    recordGameSessionLeakRecovered: jest.fn(),
   };
 
   beforeEach(async () => {


### PR DESCRIPTION
  ## 📝 개요 (Description)
                                                                                                                                                                                                                                                                                                                            
  라운드 진행 중 catch 블록이 `clearAllTimers`만 호출하고 `deleteGameSession`을 누락해, 에러 경로마다 `GameSessionManager`의 인메모리 `Map`에 좀비 세션이 영구 잔류하던 누수를 차단합니다.                                                                                                                                  
                                                                                                                                                                                                                                                                                                                            
  **1차 방어선 — catch 블록 통합**                                                                                                                                                                                                                                                                                          
  - `RoundProgressionService`의 catch 블록 7곳을 `abortGameOnError(roomId, phase, error)` 공통 헬퍼로 통합
  - 헬퍼가 **타이머 정리 + 세션 삭제 + Sentry capture(태그 포함) + 누수 회수 메트릭**을 일관되게 수행                                                                                                                                                                                                                       
  - `finishGame`은 try/catch/finally로 재구성해 정상·에러 양 경로에서 cleanup 보장                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                            
  **2차 방어선 — Idle sweeper**                                                                                                                                                                                                                                                                                             
  - `GameSession`에 `createdAt`/`lastActivityAt` 필드 추가, 상태 변경 시점마다 `touchSession()`으로 갱신                                                                                                                                                                                                                    
  - `OnModuleInit`에서 5분 주기 sweeper 시작 → 30분 이상 idle인 세션을 일괄 회수                                                                                                                                                                                                                                            
  - `OnModuleDestroy`에서 `clearInterval`로 정리                                                                                                                                                                                                                                                                            
  - Redis 이관은 ADR 08 결정대로 보류 (라운드당 100+ I/O로 UX 지연 우려), 인메모리 유지 + 안전망 추가 방식 선택                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                            
  **관측성**                                                                                                                                                                                                                                                                                                                
  - `game_session_leak_recovered_total{reason="idle"|"catch_error"}` Counter 신설                                                                                                                                                                                                                                           
  - 두 라벨 값이 0에 가까운지가 운영상 "세션 누수 건강성" 지표                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                            
  **부수 변경**                                                                                                                                                                                                                                                                                                             
  - `disconnectFromGame` → `getDisconnectInfo`로 개명 — 이름이 cleanup을 한다고 오해를 유발해 호출자의 정리 누락을 일으키던 함정 제거                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                            
  ## 🔗 관련 이슈 (Related Issues)
                                                                                                                                                                                                                                                                                                                            
  -   Closes #280                                                                                                                                                                                                                                                                                                           
   
  ## 🏷 작업 유형 (Type of Change)                                                                                                                                                                                                                                                                                          
                  
  -   [ ] ✨ 기능 추가 (New Feature)
  -   [x] 🐛 버그 수정 (Bug Fix)
  -   [ ] ♻️ 리팩토링 (Refactoring)                                                                                                                                                                                                                                                                                         
  -   [ ] 📝 문서 업데이트 (Documentation)
  -   [ ] 🔧 설정 변경 및 기타 (Config & Other)                                                                                                                                                                                                                                                                             
                  
  ## ✅ 체크리스트 (Checklist)                                                                                                                                                                                                                                                                                              ─
                  
  -   [ ] 코드가 정상적으로 컴파일/빌드 되나요?                                                                                                                                                                                                                                                                             
  -   [ ] 기존 테스트를 통과했나요? (새로운 테스트가 필요하다면 추가했나요?)
  -   [ ] 스스로 코드를 리뷰했나요? (Self-review)                                                                                                                                                                                                                                                                           
  -   [ ] 불필요한 주석이나 디버깅 코드는 제거했나요?                                                                                                                                                                                                                                                                       
  -   [ ] 문서(README 등)에 변경 사항을 업데이트했나요?
                                                                                                                                                                                                                                                                                                                            
  ## 📸 스크린샷 (Screenshots)
                                                                                                                                                                                                                                                                                                                            
  UI 변경 없음.                                                                                                                                                                                                                                                                                                             
   
  ## 🎸 기타 (Etc)                                                                                                                                                                                                                                                                                                          
                  
  **주요 변경 파일**                                                                                                                                                                                                                                                                                                        
  - `packages/backend/src/game/game-session-manager.ts` — `OnModuleInit/Destroy`, `sweepStaleSessions`, `touchSession`, `getDisconnectInfo` 개명
  - `packages/backend/src/game/round-progression.service.ts` — `abortGameOnError` 헬퍼, catch 7곳 통일, `finishGame` finally cleanup                                                                                                                                                                                        
  - `packages/backend/src/metrics/` — `game_session_leak_recovered_total` Counter, `recordGameSessionLeakRecovered(reason)` 헬퍼                                                                                                                                                                                            
  - `packages/backend/test/game-session-manager.spec.ts` — stale 30분 경과 회수 / 이하 시 유지                                                                                                                                                                                                                              
  - `packages/backend/test/round-progression.service.spec.ts` — `finishGame` DB 실패, `phaseGrading` Clova 타임아웃 등 모든 catch 경로에서 `clearAllTimers + deleteGameSession + 메트릭` 호출 검증                                                                                                                          
                                                                                                                                                                                                                                                                                                                            
  **리뷰 시 보면 좋은 포인트**                                                                                                                                                                                                                                                                                              
  - sweeper 주기(5분)/stale 기준(30분)이 게임 1판 평균 길이(~5분) 대비 여유 있는지                                                                                                                                                                                                                                          
  - `finishGame`의 finally 정리가 try 내부 emit 실패와도 충돌 없는지                                                                                                                                                                                                                                                        
  - `disconnectFromGame` 개명에 따른 호출자 누락 여부 (`game.gateway.ts`만 영향)                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                            
  **상수**                                                                                                                                                                                                                                                                                                                  
  - `SWEEP_INTERVAL_MS = 5 * 60 * 1000`                                                                                                                                                                                                                                                                                     
  - `SESSION_STALE_MS = 30 * 60 * 1000`       

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 유휴 게임 세션의 자동 정리 메커니즘 추가
  * 세션 활동 추적 기능 도입
  * 게임 세션 복구 메트릭 추가

* **Bug Fixes**
  * 에러 발생 시 게임 세션이 안정적으로 정리되도록 개선
  * 세션 리소스 누수 방지 강화

* **Refactor**
  * 게임 세션 조회 API 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->