### PR TITLE
[CHORE] ECS Fargate + S3/CloudFront + EC2 배포

### DIFF
--- a/.env.ec2.example
+++ b/.env.ec2.example
@@ -1,32 +1,9 @@
-NODE_ENV=production
+# EC2 (Redis + PostgreSQL + Prometheus + Grafana) 전용 환경변수
 
 # Database
-DB_HOST=postgres
-DB_PORT=5432
 DB_USERNAME=csarena
 DB_PASSWORD=your_strong_password_here
 DB_DATABASE=csarena
-
-# JWT (32자 이상 랜덤 문자열)
-JWT_SECRET=your_jwt_secret_min_32_chars_here
-JWT_REFRESH_SECRET=your_refresh_secret_min_32_chars_here
-
-# Frontend URL (EC2 퍼블릭 IP 또는 도메인)
-FRONTEND_URL=http://your-ec2-public-ip
-
-# GitHub OAuth
-GITHUB_CLIENT_ID=your_github_client_id
-GITHUB_CLIENT_SECRET=your_github_client_secret
-GITHUB_CALLBACK_URL=http://your-ec2-public-ip/api/auth/github/callback
-
-# Clova Studio
-CLOVA_STUDIO_API_KEY=your_clova_api_key
-
-# Sentry (선택)
-SENTRY_DSN=
-
-# Prometheus (docker 내부 네트워크에서 scrape 허용)
-PROMETHEUS_ALLOWED_CIDRS=172.0.0.0/8
 
 # Grafana
 GRAFANA_USER=admin

--- a/.env.ec2.example
+++ b/.env.ec2.example
@@ -1,0 +1,33 @@
+NODE_ENV=production
+
+# Database
+DB_HOST=postgres
+DB_PORT=5432
+DB_USERNAME=csarena
+DB_PASSWORD=your_strong_password_here
+DB_DATABASE=csarena
+
+# JWT (32자 이상 랜덤 문자열)
+JWT_SECRET=your_jwt_secret_min_32_chars_here
+JWT_REFRESH_SECRET=your_refresh_secret_min_32_chars_here
+
+# Frontend URL (EC2 퍼블릭 IP 또는 도메인)
+FRONTEND_URL=http://your-ec2-public-ip
+
+# GitHub OAuth
+GITHUB_CLIENT_ID=your_github_client_id
+GITHUB_CLIENT_SECRET=your_github_client_secret
+GITHUB_CALLBACK_URL=http://your-ec2-public-ip/api/auth/github/callback
+
+# Clova Studio
+CLOVA_STUDIO_API_KEY=your_clova_api_key
+
+# Sentry (선택)
+SENTRY_DSN=
+
+# Prometheus (docker 내부 네트워크에서 scrape 허용)
+PROMETHEUS_ALLOWED_CIDRS=172.0.0.0/8
+
+# Grafana
+GRAFANA_USER=admin
+GRAFANA_PASSWORD=your_grafana_password_here

--- a/.env.ec2.example
+++ b/.env.ec2.example
@@ -1,9 +1,15 @@
 # EC2 (Redis + PostgreSQL + Prometheus + Grafana) 전용 환경변수
 
+# EC2 네트워크
+EC2_PRIVATE_IP=172.31.x.x  # EC2 콘솔 > 인스턴스 > 프라이빗 IPv4 주소
+
 # Database
 DB_USERNAME=csarena
 DB_PASSWORD=your_strong_password_here
 DB_DATABASE=csarena
+
+# Redis
+REDIS_PASSWORD=your_strong_redis_password_here
 
 # Grafana
 GRAFANA_USER=admin

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ out/
 # Environment files (unencrypted - NEVER commit)
 .env
 .env.*
+!.env.*.example
 
 # SOPS / Age keys
 keys.txt

--- a/docker-compose-ec2.yml
+++ b/docker-compose-ec2.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - redis_data:/data
     ports:
-      - "${EC2_PRIVATE_IP}:6379:6379"
+      - "${EC2_PRIVATE_IP:?EC2_PRIVATE_IP must be set in .env.ec2}:6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "--no-auth-warning", "ping"]
       interval: 10s
@@ -37,7 +37,7 @@ services:
       - postgres_data:/var/lib/postgresql
       - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
     ports:
-      - "${EC2_PRIVATE_IP}:5432:5432"
+      - "${EC2_PRIVATE_IP:?EC2_PRIVATE_IP must be set in .env.ec2}:5432:5432"
     command:
       - "postgres"
       - "-c"
@@ -57,7 +57,9 @@ services:
       - csarena-network
     restart: unless-stopped
     environment:
-      DATA_SOURCE_NAME: "postgresql://${DB_USERNAME}:${DB_PASSWORD}@postgres:5432/${DB_DATABASE}?sslmode=disable"
+      DATA_SOURCE_URI: "postgres:5432/${DB_DATABASE}?sslmode=disable"
+      DATA_SOURCE_USER: ${DB_USERNAME}
+      DATA_SOURCE_PASS: ${DB_PASSWORD}
     volumes:
       - ./monitoring/postgres-exporter-queries.yaml:/etc/postgres-exporter/queries.yaml:ro
     command:

--- a/docker-compose-ec2.yml
+++ b/docker-compose-ec2.yml
@@ -34,7 +34,7 @@ services:
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
       - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
     ports:
       - "${EC2_PRIVATE_IP}:5432:5432"

--- a/docker-compose-ec2.yml
+++ b/docker-compose-ec2.yml
@@ -1,58 +1,4 @@
 services:
-  frontend:
-    image: ${REGISTRY:-}web05-frontend:latest
-    build:
-      context: .
-      dockerfile: packages/frontend/Dockerfile
-    container_name: csarena-frontend
-    ports:
-      - "80:80"
-    networks:
-      - csarena-network
-    depends_on:
-      backend:
-        condition: service_healthy
-    restart: unless-stopped
-
-  backend:
-    image: ${REGISTRY:-}web05-backend:latest
-    build:
-      context: .
-      dockerfile: packages/backend/Dockerfile
-    container_name: csarena-backend
-    networks:
-      - csarena-network
-    environment:
-      NODE_ENV: production
-      CORS_ORIGIN: ${FRONTEND_URL}
-      DB_HOST: postgres
-      DB_PORT: 5432
-      DB_USERNAME: ${DB_USERNAME}
-      DB_PASSWORD: ${DB_PASSWORD}
-      DB_DATABASE: ${DB_DATABASE}
-      REDIS_HOST: redis
-      REDIS_PORT: 6379
-      JWT_SECRET: ${JWT_SECRET}
-      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
-      CLOVA_STUDIO_API_KEY: ${CLOVA_STUDIO_API_KEY}
-      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
-      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
-      GITHUB_CALLBACK_URL: ${GITHUB_CALLBACK_URL}
-      SENTRY_DSN: ${SENTRY_DSN:-}
-      PROMETHEUS_ALLOWED_CIDRS: ${PROMETHEUS_ALLOWED_CIDRS:-172.0.0.0/8}
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4000/api/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s
-    restart: unless-stopped
-
   redis:
     image: redis:7-alpine
     container_name: csarena-redis
@@ -62,6 +8,8 @@ services:
     command: ["redis-server", "--appendonly", "yes", "--appendfsync", "everysec"]
     volumes:
       - redis_data:/data
+    ports:
+      - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -81,6 +29,8 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql
       - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
+    ports:
+      - "5432:5432"
     command:
       - "postgres"
       - "-c"
@@ -119,6 +69,7 @@ services:
       - "127.0.0.1:9090:9090"
     volumes:
       - ./monitoring/prometheus-ec2.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/sd:/etc/prometheus/sd:ro
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'

--- a/docker-compose-ec2.yml
+++ b/docker-compose-ec2.yml
@@ -51,7 +51,7 @@ services:
       retries: 5
 
   postgres-exporter:
-    image: prometheuscommunity/postgres-exporter:v0.15.0
+    image: prometheuscommunity/postgres-exporter:v0.19.1
     container_name: csarena-postgres-exporter
     networks:
       - csarena-network
@@ -67,7 +67,7 @@ services:
         condition: service_healthy
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.2.1
     container_name: csarena-prometheus
     networks:
       - csarena-network
@@ -84,7 +84,7 @@ services:
       - '--web.enable-lifecycle'
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:11.4.0
     container_name: csarena-grafana
     networks:
       - csarena-network

--- a/docker-compose-ec2.yml
+++ b/docker-compose-ec2.yml
@@ -5,13 +5,20 @@ services:
     networks:
       - csarena-network
     restart: unless-stopped
-    command: ["redis-server", "--appendonly", "yes", "--appendfsync", "everysec"]
+    command:
+      - "redis-server"
+      - "--appendonly"
+      - "yes"
+      - "--appendfsync"
+      - "everysec"
+      - "--requirepass"
+      - "${REDIS_PASSWORD}"
     volumes:
       - redis_data:/data
     ports:
-      - "6379:6379"
+      - "${EC2_PRIVATE_IP}:6379:6379"
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "--no-auth-warning", "ping"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -30,7 +37,7 @@ services:
       - postgres_data:/var/lib/postgresql
       - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
     ports:
-      - "5432:5432"
+      - "${EC2_PRIVATE_IP}:5432:5432"
     command:
       - "postgres"
       - "-c"

--- a/docker-compose-ec2.yml
+++ b/docker-compose-ec2.yml
@@ -34,7 +34,7 @@ services:
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     volumes:
-      - postgres_data:/var/lib/postgresql
+      - postgres_data:/var/lib/postgresql/data
       - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
     ports:
       - "${EC2_PRIVATE_IP}:5432:5432"

--- a/docker-compose-ec2.yml
+++ b/docker-compose-ec2.yml
@@ -92,7 +92,7 @@ services:
       - csarena-network
     restart: unless-stopped
     ports:
-      - "127.0.0.1:3001:3000"
+      - "3001:3000"
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro

--- a/docker-compose-ec2.yml
+++ b/docker-compose-ec2.yml
@@ -1,0 +1,155 @@
+services:
+  frontend:
+    image: ${REGISTRY:-}web05-frontend:latest
+    build:
+      context: .
+      dockerfile: packages/frontend/Dockerfile
+    container_name: csarena-frontend
+    ports:
+      - "80:80"
+    networks:
+      - csarena-network
+    depends_on:
+      backend:
+        condition: service_healthy
+    restart: unless-stopped
+
+  backend:
+    image: ${REGISTRY:-}web05-backend:latest
+    build:
+      context: .
+      dockerfile: packages/backend/Dockerfile
+    container_name: csarena-backend
+    networks:
+      - csarena-network
+    environment:
+      NODE_ENV: production
+      CORS_ORIGIN: ${FRONTEND_URL}
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_DATABASE: ${DB_DATABASE}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
+      CLOVA_STUDIO_API_KEY: ${CLOVA_STUDIO_API_KEY}
+      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
+      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
+      GITHUB_CALLBACK_URL: ${GITHUB_CALLBACK_URL}
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      PROMETHEUS_ALLOWED_CIDRS: ${PROMETHEUS_ALLOWED_CIDRS:-172.0.0.0/8}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: csarena-redis
+    networks:
+      - csarena-network
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes", "--appendfsync", "everysec"]
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  postgres:
+    image: postgres:18.1
+    container_name: csarena-postgres
+    networks:
+      - csarena-network
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${DB_DATABASE}
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql
+      - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_preload_libraries=pg_stat_statements"
+      - "-c"
+      - "pg_stat_statements.track=all"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_DATABASE}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:v0.15.0
+    container_name: csarena-postgres-exporter
+    networks:
+      - csarena-network
+    restart: unless-stopped
+    environment:
+      DATA_SOURCE_NAME: "postgresql://${DB_USERNAME}:${DB_PASSWORD}@postgres:5432/${DB_DATABASE}?sslmode=disable"
+    volumes:
+      - ./monitoring/postgres-exporter-queries.yaml:/etc/postgres-exporter/queries.yaml:ro
+    command:
+      - '--extend.query-path=/etc/postgres-exporter/queries.yaml'
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: csarena-prometheus
+    networks:
+      - csarena-network
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:9090:9090"
+    volumes:
+      - ./monitoring/prometheus-ec2.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.enable-lifecycle'
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: csarena-grafana
+    networks:
+      - csarena-network
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3001:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    depends_on:
+      - prometheus
+
+networks:
+  csarena-network:
+    driver: bridge
+
+volumes:
+  redis_data:
+  postgres_data:
+  prometheus_data:
+  grafana_data:

--- a/monitoring/prometheus-ec2.yml
+++ b/monitoring/prometheus-ec2.yml
@@ -3,10 +3,13 @@ global:
   evaluation_interval: 15s
 
 scrape_configs:
-  - job_name: 'nestjs-backend'
-    metrics_path: /api/metrics
-    static_configs:
-      - targets: ['backend:4000']
+  # TODO: ECS Fargate 태스크는 EC2 Docker 네트워크와 분리되어 있어 backend:4000 DNS가
+  # 해석되지 않는다. ALB internal DNS를 타겟으로 사용하거나 ECS 태스크에서
+  # remote_write로 push하는 방식으로 재설계가 필요하다.
+  # - job_name: 'nestjs-backend'
+  #   metrics_path: /api/metrics
+  #   static_configs:
+  #     - targets: ['backend:4000']
 
   - job_name: 'postgres'
     static_configs:

--- a/monitoring/prometheus-ec2.yml
+++ b/monitoring/prometheus-ec2.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'nestjs-backend'
+    metrics_path: /api/metrics
+    static_configs:
+      - targets: ['backend:4000']
+
+  - job_name: 'postgres'
+    static_configs:
+      - targets: ['postgres-exporter:9187']

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -45,6 +45,9 @@ COPY --from=builder --chown=nestjs:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=nestjs:nodejs /app/packages/backend/dist ./dist
 COPY --from=builder --chown=nestjs:nodejs /app/packages/backend/package.json ./package.json
 
+# Create logs directory with proper permissions
+RUN mkdir -p logs && chown nestjs:nodejs logs
+
 # Switch to non-root user
 USER nestjs
 

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -43,8 +43,8 @@ const typeOrmModule = TypeOrmModule.forRootAsync({
     database: configService.get('DB_DATABASE', 'boostcamp'),
     entities: [__dirname + '/**/*.entity{.ts,.js}'],
     synchronize:
-      configService.get('NODE_ENV') !== 'production' ||
-      configService.get('DB_SYNCHRONIZE') === 'true',
+      configService.get('NODE_ENV') !== 'production' &&
+      configService.get('DB_SYNCHRONIZE') !== 'false',
     logging: configService.get('NODE_ENV') === 'development',
   }),
   inject: [ConfigService],

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -43,8 +43,9 @@ const typeOrmModule = TypeOrmModule.forRootAsync({
     database: configService.get('DB_DATABASE', 'boostcamp'),
     entities: [__dirname + '/**/*.entity{.ts,.js}'],
     synchronize:
-      configService.get('NODE_ENV') !== 'production' &&
-      configService.get('DB_SYNCHRONIZE') !== 'false',
+      configService.get('DB_SYNCHRONIZE') === 'true' ||
+      (configService.get('NODE_ENV') !== 'production' &&
+        configService.get('DB_SYNCHRONIZE') !== 'false'),
     logging: configService.get('NODE_ENV') === 'development',
   }),
   inject: [ConfigService],

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -62,6 +62,7 @@ const metadata: ModuleMetadata = {
         connection: {
           host: configService.get('REDIS_HOST', 'localhost'),
           port: parseInt(configService.get('REDIS_PORT', '6379'), 10),
+          password: configService.get('REDIS_PASSWORD') || undefined,
         },
       }),
       inject: [ConfigService],

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -42,7 +42,9 @@ const typeOrmModule = TypeOrmModule.forRootAsync({
     password: configService.get('DB_PASSWORD', 'postgres'),
     database: configService.get('DB_DATABASE', 'boostcamp'),
     entities: [__dirname + '/**/*.entity{.ts,.js}'],
-    synchronize: configService.get('NODE_ENV') !== 'production',
+    synchronize:
+      configService.get('NODE_ENV') !== 'production' ||
+      configService.get('DB_SYNCHRONIZE') === 'true',
     logging: configService.get('NODE_ENV') === 'development',
   }),
   inject: [ConfigService],

--- a/packages/backend/src/common/redis-io-adapter.ts
+++ b/packages/backend/src/common/redis-io-adapter.ts
@@ -28,9 +28,12 @@ export class RedisIoAdapter extends IoAdapter {
   }
 
   async connectToRedis(): Promise<void> {
-    const pubClient = createClient({
-      url: `redis://${this.redisHost}:${this.redisPort}`,
-    });
+    const password = process.env.REDIS_PASSWORD;
+    const url = password
+      ? `redis://:${password}@${this.redisHost}:${this.redisPort}`
+      : `redis://${this.redisHost}:${this.redisPort}`;
+
+    const pubClient = createClient({ url });
 
     const subClient = pubClient.duplicate();
 

--- a/packages/backend/src/common/redis-io-adapter.ts
+++ b/packages/backend/src/common/redis-io-adapter.ts
@@ -28,12 +28,10 @@ export class RedisIoAdapter extends IoAdapter {
   }
 
   async connectToRedis(): Promise<void> {
-    const password = process.env.REDIS_PASSWORD;
-    const url = password
-      ? `redis://:${password}@${this.redisHost}:${this.redisPort}`
-      : `redis://${this.redisHost}:${this.redisPort}`;
-
-    const pubClient = createClient({ url });
+    const pubClient = createClient({
+      socket: { host: this.redisHost, port: this.redisPort },
+      password: process.env.REDIS_PASSWORD || undefined,
+    });
 
     const subClient = pubClient.duplicate();
 

--- a/packages/backend/src/common/redis.module.ts
+++ b/packages/backend/src/common/redis.module.ts
@@ -12,10 +12,12 @@ export const REDIS_CLIENT = 'REDIS_CLIENT';
         const logger = new Logger('RedisModule');
         const host = process.env.REDIS_HOST || 'localhost';
         const port = parseInt(process.env.REDIS_PORT || '6379', 10);
+        const password = process.env.REDIS_PASSWORD || undefined;
 
         const client = new Redis({
           host,
           port,
+          password,
           // 지수 백오프만 유지 — null 반환 시 영구 재연결 포기가 되어
           // 네트워크 블립/Redis 재시작/페일오버 이후 복구 불능에 빠짐.
           // 장애 감지는 'error'/'end' 이벤트 로깅으로 처리.

--- a/packages/backend/src/common/winston.config.ts
+++ b/packages/backend/src/common/winston.config.ts
@@ -1,19 +1,23 @@
 import * as winston from 'winston';
 import DailyRotateFile from 'winston-daily-rotate-file';
 
-export const feedbackLoggerConfig = {
-  format: winston.format.combine(winston.format.timestamp(), winston.format.json()),
-  transports: [
-    new winston.transports.Console(),
+const transports: winston.transport[] = [new winston.transports.Console()];
 
+if (process.env.NODE_ENV !== 'production') {
+  transports.push(
     new DailyRotateFile({
       level: 'info',
-      dirname: '/tmp/logs/feedbacks',
-      filename: 'feedback-%DATE%.log', // 파일명 예: feedback-2025-01-06.log
+      dirname: 'logs/feedbacks',
+      filename: 'feedback-%DATE%.log',
       datePattern: 'YYYY-MM-DD',
-      zippedArchive: true, // 지난 로그는 압축해서 용량 절약
-      maxSize: '20m', // 파일 하나가 20MB 넘으면 분리
-      maxFiles: '14d', // 14일치만 보관하고 오래된 건 자동 삭제
+      zippedArchive: true,
+      maxSize: '20m',
+      maxFiles: '14d',
     }),
-  ],
+  );
+}
+
+export const feedbackLoggerConfig = {
+  format: winston.format.combine(winston.format.timestamp(), winston.format.json()),
+  transports,
 };

--- a/packages/backend/src/common/winston.config.ts
+++ b/packages/backend/src/common/winston.config.ts
@@ -17,7 +17,13 @@ if (process.env.NODE_ENV !== 'production') {
   );
 }
 
+const formats = [winston.format.timestamp(), winston.format.json()];
+
+if (process.env.NODE_ENV === 'production') {
+  formats.unshift(winston.format.uncolorize());
+}
+
 export const feedbackLoggerConfig = {
-  format: winston.format.combine(winston.format.timestamp(), winston.format.json()),
+  format: winston.format.combine(...formats),
   transports,
 };

--- a/packages/backend/src/common/winston.config.ts
+++ b/packages/backend/src/common/winston.config.ts
@@ -8,7 +8,7 @@ export const feedbackLoggerConfig = {
 
     new DailyRotateFile({
       level: 'info',
-      dirname: process.env.NODE_ENV === 'production' ? '/tmp/logs/feedbacks' : 'logs/feedbacks',
+      dirname: '/tmp/logs/feedbacks',
       filename: 'feedback-%DATE%.log', // 파일명 예: feedback-2025-01-06.log
       datePattern: 'YYYY-MM-DD',
       zippedArchive: true, // 지난 로그는 압축해서 용량 절약

--- a/packages/backend/src/common/winston.config.ts
+++ b/packages/backend/src/common/winston.config.ts
@@ -8,7 +8,7 @@ export const feedbackLoggerConfig = {
 
     new DailyRotateFile({
       level: 'info',
-      dirname: 'logs/feedbacks', // 프로젝트 루트의 logs/feedbacks 폴더에 저장
+      dirname: process.env.NODE_ENV === 'production' ? '/tmp/logs/feedbacks' : 'logs/feedbacks',
       filename: 'feedback-%DATE%.log', // 파일명 예: feedback-2025-01-06.log
       datePattern: 'YYYY-MM-DD',
       zippedArchive: true, // 지난 로그는 압축해서 용량 절약

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -7,9 +7,11 @@ import cookieParser from 'cookie-parser';
 import compression from 'compression';
 import type { Application } from 'express';
 import { RedisIoAdapter } from './common/redis-io-adapter';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
 
   (app.getHttpAdapter().getInstance() as Application).set('trust proxy', 1);
   app.use(compression());

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -10,7 +10,7 @@ import { RedisIoAdapter } from './common/redis-io-adapter';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, { bufferLogs: true });
   app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
 
   (app.getHttpAdapter().getInstance() as Application).set('trust proxy', 1);

--- a/packages/frontend/nginx.conf
+++ b/packages/frontend/nginx.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name 175.45.195.233;
+    server_name _;
     root /usr/share/nginx/html;
     index index.html;
 


### PR DESCRIPTION
## 📝 개요 (Description)

ECS Fargate + S3/CloudFront + EC2 구조로 CSArena를 배포하기 위한 인프라 구성 및 코드 수정입니다.

**아키텍처**

```
CloudFront → /api/*, /socket.io/*, /ws* → ALB → ECS Fargate (backend)
           → /*                          → S3 (React SPA)

ECS Fargate backend → EC2 private IP
                       ├─ Redis  6379
                       └─ PostgreSQL  5432
```

**변경 사항:**

- `docker-compose-ec2.yml` 추가: EC2 전용 인프라(Redis, PostgreSQL, prometheus, grafana) 구성
- `monitoring/prometheus-ec2.yml` 추가: EC2 환경용 Prometheus 스크레이프 설정
- `.env.ec2.example` 추가: EC2 인프라 구동에 필요한 환경변수 예시
- `.gitignore`: `.env.*.example` 파일이 커밋되도록 예외 추가
- `packages/backend/Dockerfile`: `nestjs` 비루트 유저를 위해 `logs/` 디렉토리 사전 생성
- `packages/backend/src/common/winston.config.ts`: `production` 환경에서 파일 로그 트랜스포트 비활성화 및 `uncolorize()` 포맷 추가 (CloudWatch에서 ANSI 색상 코드 제거)
- `packages/backend/src/main.ts`: `app.useLogger()`로 NestJS 프레임워크 로그를 Winston으로 라우팅
- `packages/backend/src/app.module.ts`: `DB_SYNCHRONIZE=true` 환경변수로 production에서도 TypeORM schema sync를 허용 (초기 배포 시 빈 DB에 테이블 생성 용도)
- `packages/frontend/nginx.conf`: `server_name` 고정 IP → `_` (와일드카드)로 변경

## 🔗 관련 이슈 (Related Issues)

- closes #284

## 🏷️ 작업 유형 (Type of Change)

- [ ] ✨ 기능 추가 (New Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [x] 🔧 설정 변경 및 기타 (Config & Other)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 컴파일/빌드 되나요?
- [x] 기존 테스트를 통과했나요? (새로운 테스트가 필요하다면 추가했나요?)
- [x] 스스로 코드를 리뷰했나요? (Self-review)
- [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
- [ ] 문서(README 등)에 변경 사항을 업데이트했나요?

## 📸 스크린샷 (Screenshots)

ECS 서비스 정상 실행 확인 (CloudWatch 로그)

<img width="1148" height="139" alt="image" src="https://github.com/user-attachments/assets/c813fb9d-1da7-4718-8e91-4335f73f6821" />

<img width="625" height="34" alt="image" src="https://github.com/user-attachments/assets/b0328aa1-8e86-4cca-a2af-ccb1ba54c51f" />

## 🎸 기타 (Etc)

**production에서 파일 로그를 비활성화하고 CloudWatch용 JSON 로그로 전환한 이유**

ECS Fargate 컨테이너는 비루트 유저(`nestjs`)로 실행되어 `/app/logs/` 디렉토리를 런타임에 생성할 수 없다. ECS 환경에서는 stdout 로그를 CloudWatch Logs로 수집하므로 파일 로그가 불필요하다.

또한 `WinstonModule.forRoot()`만으로는 NestJS 프레임워크 레벨 로그(`[RouterExplorer]`, `[NestFactory]` 등)가 기본 로거를 거쳐 ANSI 색상 코드(`[32m`, `[39m`)가 CloudWatch에 그대로 출력된다. `app.useLogger()`로 모든 로그를 Winston으로 라우팅하고 `uncolorize()` 포맷을 적용해 JSON 형태로 정제했다.

**DB_SYNCHRONIZE 환경변수**

`NODE_ENV=production`이면 TypeORM `synchronize: false`가 기본이다. 초기 배포 시 빈 DB에 테이블을 생성하려면 태스크 정의에 `DB_SYNCHRONIZE=true`를 추가해 1회 배포 후 제거한다. 이후 스키마 변경은 마이그레이션으로 관리한다.

**:latest 태그 금지**

ECS는 versionConsistency 기능으로 이미지 태그를 최초 pull 시점의 digest로 고정한다. ECR에 새 이미지를 올리고 Force New Deployment를 해도 같은 태그면 구 digest가 유지된다. 반드시 버전 태그(`:v1`, `:v2`)를 명시하고 태스크 정의를 새 리비전으로 등록해야 새 이미지가 반영된다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * EC2 환경 배포 지원 추가
  * 모니터링 스택 통합 (Redis, PostgreSQL, Prometheus, Grafana)

* **보안 개선**
  * Redis 및 데이터베이스 비밀번호 인증 지원

* **Chores**
  * 환경 설정 파일 업데이트
  * 프로덕션 로깅 설정 최적화
  * Nginx 설정 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->