### PR TITLE
test: AWS Fargate 부하 한계 측정 자산 추가 (load-limit-cloud)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ lerna-debug.log*
 *.tsbuildinfo
 
 .claude
+
+# Benchmark artifacts (측정 호스트 환경 의존, 큰 데이터)
+scripts/benchmarks/**/results/
+scripts/benchmarks/**/tokens.json

--- a/scripts/benchmarks/load-limit-cloud/README.md
+++ b/scripts/benchmarks/load-limit-cloud/README.md
@@ -30,7 +30,7 @@ CSArena 백엔드의 동시 활성 룸 한계를 **AWS ECS Fargate 환경**에�
 
 12번과 동일 (`scripts/benchmarks/load-limit/load-test-rooms.js` 그대로 재사용). `NGINX_URL` 환경변수로 endpoint만 교체.
 
-```
+```bash
 connect → CONNECT(/ws,token) → connect:completed → match:enqueue
   → match:found → round:ready → round:start → submit:answer
   → round:result → close
@@ -83,6 +83,7 @@ CF_DNS=dm2twkzzyg6a9.cloudfront.net
 `task-definitions/bench-{512,1024,2048}.json`은 secrets와 측정 호스트 IP를 placeholder로 두고 커밋되어 있음. 측정 시작 전 반드시 production 값을 주입해야 한다.
 
 치환 대상:
+
 | placeholder | 값 출처 |
 |---|---|
 | `REPLACE_WITH_PRODUCTION_DB_PASSWORD` | production task definition v17의 `DB_PASSWORD` |
@@ -146,6 +147,19 @@ aws ecs register-task-definition --region ap-northeast-2 \
 ```
 
 각 명령 출력의 `revision` 번호를 기록 (예: `csarena-backend-bench-512:1`).
+
+### 1-5. ⚠️ 측정 시작 전 — production task definition revision 캡처 (필수)
+
+원복 시점에 의도치 않은 다운그레이드를 방지하기 위해 **시작 직전의 production task definition을 변수에 저장**한다. 측정 도중 누가 production을 업데이트해도 종료 시 정확한 시점으로 돌아갈 수 있음.
+
+```bash
+ORIG_TASK_DEF=$(aws ecs describe-services --region ap-northeast-2 \
+  --cluster csarena-cluster --services csarena-backend \
+  --query "services[0].taskDefinition" --output text)
+echo "ORIG_TASK_DEF=$ORIG_TASK_DEF"
+```
+
+이 값을 측정 종료까지 셸 환경에 유지. **새 터미널 열면 다시 export 필수.** 단계 7(원복)에서 사용.
 
 ### 2. EC2 PostgreSQL에 1000명 시드
 
@@ -299,21 +313,26 @@ done
 
 ### 7. ⚠️ production task definition 원복 (필수)
 
-**측정 끝나면 반드시 v14로 되돌리기**. PROMETHEUS_ALLOWED_CIDRS 외부 IP 노출도 자동으로 닫힘.
+**측정 끝나면 반드시 단계 1-5에서 캡처한 `$ORIG_TASK_DEF`로 되돌리기.** PROMETHEUS_ALLOWED_CIDRS 외부 IP 노출도 자동으로 닫힘.
+
+> 특정 revision(예: `csarena-backend:14`)으로 하드코딩하면 측정 시작 시점의 실제 task definition과 달라 의도치 않은 다운그레이드가 발생할 수 있음. 반드시 단계 1-5에서 캡처한 값을 사용.
 
 ```bash
+echo "원복 대상: $ORIG_TASK_DEF"
+
 aws ecs update-service --region ap-northeast-2 \
   --cluster csarena-cluster \
   --service csarena-backend \
-  --task-definition csarena-backend:14
+  --task-definition "$ORIG_TASK_DEF"
 
 aws ecs wait services-stable --region ap-northeast-2 \
   --cluster csarena-cluster --services csarena-backend
 
-# 검증 — 다시 v14로 돌아왔는지
-aws ecs describe-services --region ap-northeast-2 \
+# 검증 — ORIG_TASK_DEF로 정확히 돌아왔는지
+CURRENT=$(aws ecs describe-services --region ap-northeast-2 \
   --cluster csarena-cluster --services csarena-backend \
-  --query "services[0].taskDefinition"
+  --query "services[0].taskDefinition" --output text)
+[[ "$CURRENT" == "$ORIG_TASK_DEF" ]] && echo "OK: 원복 완료" || echo "WARN: 불일치 ($CURRENT)"
 ```
 
 ### 8. CloudWatch에서 CPU/mem 사후 조회
@@ -362,7 +381,7 @@ done
 
 ## 산출물 (예상)
 
-```
+```bash
 results/
   bench512-rooms{50,100,200,500}-metrics.csv     ← 사이드카 ELU 1초
   bench512-rooms{50,100,200,500}-k6.json         ← k6 latency

--- a/scripts/benchmarks/load-limit-cloud/README.md
+++ b/scripts/benchmarks/load-limit-cloud/README.md
@@ -1,0 +1,385 @@
+# 부하 한계 측정 — 클라우드 (load-limit-cloud)
+
+CSArena 백엔드의 동시 활성 룸 한계를 **AWS ECS Fargate 환경**에서 측정.
+
+12번(로컬 M3 Pro) 측정의 후속편. 같은 한계 정의 + 같은 시나리오로 환경만 바꿔, "Fargate vCPU별 동시 룸 한계 + 12번 결과 재현 여부"를 정량화한다.
+
+## 한계 정의 (12번과 동일 — 사전 못박기)
+
+| 기준 | 임계 | 데이터 출처 |
+|---|---|---|
+| 이벤트 루프 활용도 | `process_event_loop_utilization` > 0.85 (지속) | `/api/metrics` (1초 사이드카) |
+| 컨테이너 CPU | CPUUtilization > 90% (지속) | CloudWatch (1분 사후 조회) |
+| 컨테이너 메모리 | MemoryUtilization > 90% (지속) | CloudWatch (1분 사후 조회) |
+| 컨테이너 OOM | task stop reason = `OutOfMemoryError` | CloudWatch Logs / `aws ecs describe-tasks` |
+| `submit_ack_duration` p95 | > 200ms | k6 |
+
+> CPU/메모리 1분 해상도는 한계 정의가 "지속" 임계라 자연스럽게 맞물림. ELU만 1초 granularity로 잡으면 한계 판정에 충분 (12번 결론: 1차 병목은 일관되게 ELU).
+
+## 측정 매트릭스
+
+| 환경 | family | cpu / memory | task definition |
+|---|---|---|---|
+| Fargate 0.5 vCPU | `csarena-backend-bench-512` | 512 / 1024 | `task-definitions/bench-512.json` |
+| Fargate 1 vCPU | `csarena-backend-bench-1024` | 1024 / 2048 | `task-definitions/bench-1024.json` |
+| Fargate 2 vCPU | `csarena-backend-bench-2048` | 2048 / 4096 | `task-definitions/bench-2048.json` |
+
+각 환경 × 룸 수 단계(50, 100, 200, 500) = **총 12회 측정.**
+
+## 시뮬레이션 시나리오
+
+12번과 동일 (`scripts/benchmarks/load-limit/load-test-rooms.js` 그대로 재사용). `NGINX_URL` 환경변수로 endpoint만 교체.
+
+```
+connect → CONNECT(/ws,token) → connect:completed → match:enqueue
+  → match:found → round:ready → round:start → submit:answer
+  → round:result → close
+```
+
+채점은 `BENCH_GRADING_BYPASS=true`로 우회 (BENCH task definition에 자동 주입).
+
+## 표기 규칙 (금지/허용 — 12번과 동일)
+
+| 금지 | 허용 |
+|---|---|
+| "t3.micro 모사" | "Fargate 0.5 vCPU / 1 GB · ap-northeast-2" |
+| "1000 룸 안정 운영" | "Fargate 1 vCPU 환경에서 N 룸까지 ELU < 0.85" |
+| "프로덕션 부하" | "k6 합성 부하 (단일 라운드 시뮬레이션)" |
+
+## 비스코프
+
+- REST API 부하 한계 측정 (별도 측정 영역)
+- 답안 제출 빈도 폭주 시나리오 (별도)
+- ElastiCache·RDS 이관 후 측정 (출시 시점 별개 작업)
+
+---
+
+## 실행 절차
+
+### 0. 사전 준비
+
+**0-1. AWS 자격증명 확인**
+
+```bash
+export AWS_PROFILE=csarena-team   # 또는 본인 프로필
+aws sts get-caller-identity --region ap-northeast-2
+```
+
+**0-2. 핵심 endpoint 조회**
+
+```bash
+# ALB DNS — 사이드카 수집기에서 사용
+ALB_DNS=$(aws elbv2 describe-load-balancers --region ap-northeast-2 \
+  --names csarena-alb \
+  --query "LoadBalancers[0].DNSName" --output text)
+echo "ALB_DNS: $ALB_DNS"
+
+# CloudFront DNS — k6에서 사용 (production endpoint와 동일)
+CF_DNS=dm2twkzzyg6a9.cloudfront.net
+```
+
+**0-3. task definition placeholder 치환 (필수)**
+
+`task-definitions/bench-{512,1024,2048}.json`은 secrets와 측정 호스트 IP를 placeholder로 두고 커밋되어 있음. 측정 시작 전 반드시 production 값을 주입해야 한다.
+
+치환 대상:
+| placeholder | 값 출처 |
+|---|---|
+| `REPLACE_WITH_PRODUCTION_DB_PASSWORD` | production task definition v17의 `DB_PASSWORD` |
+| `REPLACE_WITH_PRODUCTION_REDIS_PASSWORD` | 동상 `REDIS_PASSWORD` |
+| `REPLACE_WITH_PRODUCTION_JWT_SECRET` | 동상 `JWT_SECRET` |
+| `REPLACE_WITH_PRODUCTION_JWT_REFRESH_SECRET` | 동상 `JWT_REFRESH_SECRET` |
+| `REPLACE_WITH_GITHUB_CLIENT_ID` | 동상 `GITHUB_CLIENT_ID` |
+| `REPLACE_WITH_GITHUB_CLIENT_SECRET` | 동상 `GITHUB_CLIENT_SECRET` |
+| `REPLACE_WITH_BENCH_HOST_PUBLIC_IP` | 측정 호스트 공인 IP — `curl -s -4 ifconfig.me` |
+
+production v17 값 일괄 조회:
+
+```bash
+aws ecs describe-task-definition --region ap-northeast-2 \
+  --task-definition csarena-backend:17 \
+  --query "taskDefinition.containerDefinitions[0].environment" \
+  --output json
+```
+
+치환 (예시 — 본인 값으로 교체):
+
+```bash
+MY_IP=$(curl -s -4 ifconfig.me)
+echo "My public IP: $MY_IP"
+
+# 3개 파일 일괄 치환
+for f in task-definitions/bench-{512,1024,2048}.json; do
+  sed -i.bak \
+    -e "s|REPLACE_WITH_BENCH_HOST_PUBLIC_IP|${MY_IP}|g" \
+    -e "s|REPLACE_WITH_PRODUCTION_DB_PASSWORD|<production DB_PASSWORD>|g" \
+    -e "s|REPLACE_WITH_PRODUCTION_REDIS_PASSWORD|<production REDIS_PASSWORD>|g" \
+    -e "s|REPLACE_WITH_PRODUCTION_JWT_SECRET|<production JWT_SECRET>|g" \
+    -e "s|REPLACE_WITH_PRODUCTION_JWT_REFRESH_SECRET|<production JWT_REFRESH_SECRET>|g" \
+    -e "s|REPLACE_WITH_GITHUB_CLIENT_ID|<production GITHUB_CLIENT_ID>|g" \
+    -e "s|REPLACE_WITH_GITHUB_CLIENT_SECRET|<production GITHUB_CLIENT_SECRET>|g" \
+    "$f"
+done
+```
+
+> ⚠️ 치환된 파일은 **절대 커밋하지 말 것**. `.bak` 파일도 정리.
+
+**0-4. k6 설치 확인**
+
+```bash
+k6 version   # v1.6.x 이상
+```
+
+### 1. BENCH task definition 3종 등록
+
+```bash
+cd scripts/benchmarks/load-limit-cloud
+
+aws ecs register-task-definition --region ap-northeast-2 \
+  --cli-input-json file://task-definitions/bench-512.json
+
+aws ecs register-task-definition --region ap-northeast-2 \
+  --cli-input-json file://task-definitions/bench-1024.json
+
+aws ecs register-task-definition --region ap-northeast-2 \
+  --cli-input-json file://task-definitions/bench-2048.json
+```
+
+각 명령 출력의 `revision` 번호를 기록 (예: `csarena-backend-bench-512:1`).
+
+### 2. EC2 PostgreSQL에 1000명 시드
+
+EC2 PG는 private IP(172.31.44.173)라 로컬에서 직접 접근 불가. **SSH 터널** 또는 **EC2 직접 실행** 필요.
+
+**옵션 A — SSH 터널 (권장)**
+
+```bash
+# 별도 터미널에서 터널 유지
+ssh -i ~/csarena.pem -L 5432:172.31.44.173:5432 ec2-user@13.125.237.251 -N
+
+# 메인 터미널에서 시드 실행
+PGPASSWORD='<production DB_PASSWORD>' psql -h localhost -p 5432 -U csarena -d csarena \
+  < ../load-limit/seed-bench-users-1000.sql
+```
+
+**옵션 B — EC2에서 직접 실행**
+
+```bash
+scp -i ~/csarena.pem ../load-limit/seed-bench-users-1000.sql ec2-user@13.125.237.251:/tmp/
+ssh -i ~/csarena.pem ec2-user@13.125.237.251 \
+  "PGPASSWORD='<production DB_PASSWORD>' psql -h 172.31.44.173 -U csarena -d csarena < /tmp/seed-bench-users-1000.sql"
+```
+
+### 3. JWT 토큰 1000개 발급
+
+production과 동일한 `JWT_SECRET`을 사용해야 backend가 토큰 검증 통과. SSH 터널이 켜진 상태여야 동적 user 조회 가능.
+
+```bash
+cd ../websocket-multi-instance
+
+JWT_SECRET='<production JWT_SECRET>' \
+  DB_HOST=localhost DB_PORT=5432 \
+  DB_USER=csarena DB_PASSWORD='<production DB_PASSWORD>' DB_NAME=csarena \
+  node sign-bench-tokens.mjs
+
+# 확인 — 1000개 entry
+jq 'length' tokens.json
+```
+
+(`sign-bench-tokens.mjs`의 환경변수 이름이 다르면 스크립트 내부 변수명에 맞춰 export. `<...>` 부분은 production task definition v17에서 받아 채울 것 — 절대 커밋 금지)
+
+### 4. 측정 — 환경 1 (Fargate 0.5 vCPU)
+
+**4-1. production service를 BENCH task definition으로 일시 교체**
+
+```bash
+aws ecs update-service --region ap-northeast-2 \
+  --cluster csarena-cluster \
+  --service csarena-backend \
+  --task-definition csarena-backend-bench-512
+
+# 새 task가 healthy 될 때까지 대기 (~1~2분)
+aws ecs wait services-stable --region ap-northeast-2 \
+  --cluster csarena-cluster --services csarena-backend
+```
+
+**4-2. 측정 endpoint 검증**
+
+```bash
+# health check
+curl -i https://${CF_DNS}/api/health
+
+# /api/metrics 접근 (사이드카 수집기 사전 검증)
+curl -sS http://${ALB_DNS}/api/metrics | head -5
+# → 200 응답이면 OK. 403이면 PROMETHEUS_ALLOWED_CIDRS 다시 확인
+```
+
+**4-3. 룸 4단계 부하 — 각 단계마다 사이드카 수집기 동시 실행**
+
+```bash
+cd scripts/benchmarks/load-limit-cloud
+
+for ROOMS in 50 100 200 500; do
+  echo "=== bench-512 / ROOMS=$ROOMS ==="
+
+  # 사이드카 백그라운드
+  ALB_URL=http://${ALB_DNS} ./collect-bench-cloud.sh \
+    > results/bench512-rooms${ROOMS}-metrics.csv \
+    2> results/bench512-rooms${ROOMS}-collect.err &
+  COLLECT_PID=$!
+
+  # k6 부하 (CloudFront endpoint = production endpoint)
+  NGINX_URL=wss://${CF_DNS} k6 run \
+    -e ROOMS=$ROOMS -e DURATION=2m \
+    --summary-export=results/bench512-rooms${ROOMS}-k6.json \
+    ../load-limit/load-test-rooms.js
+
+  kill $COLLECT_PID
+  wait $COLLECT_PID 2>/dev/null
+
+  # 다음 단계 전 안정화 대기 (active 룸 cleanup)
+  sleep 60
+done
+```
+
+### 5. 측정 — 환경 2 (Fargate 1 vCPU)
+
+```bash
+aws ecs update-service --region ap-northeast-2 \
+  --cluster csarena-cluster --service csarena-backend \
+  --task-definition csarena-backend-bench-1024
+
+aws ecs wait services-stable --region ap-northeast-2 \
+  --cluster csarena-cluster --services csarena-backend
+
+# 4-3 루프 반복 (파일명 prefix만 bench1024-로 변경)
+for ROOMS in 50 100 200 500; do
+  ALB_URL=http://${ALB_DNS} ./collect-bench-cloud.sh \
+    > results/bench1024-rooms${ROOMS}-metrics.csv \
+    2> results/bench1024-rooms${ROOMS}-collect.err &
+  COLLECT_PID=$!
+
+  NGINX_URL=wss://${CF_DNS} k6 run \
+    -e ROOMS=$ROOMS -e DURATION=2m \
+    --summary-export=results/bench1024-rooms${ROOMS}-k6.json \
+    ../load-limit/load-test-rooms.js
+
+  kill $COLLECT_PID
+  wait $COLLECT_PID 2>/dev/null
+  sleep 60
+done
+```
+
+### 6. 측정 — 환경 3 (Fargate 2 vCPU)
+
+```bash
+aws ecs update-service --region ap-northeast-2 \
+  --cluster csarena-cluster --service csarena-backend \
+  --task-definition csarena-backend-bench-2048
+
+aws ecs wait services-stable --region ap-northeast-2 \
+  --cluster csarena-cluster --services csarena-backend
+
+for ROOMS in 50 100 200 500; do
+  ALB_URL=http://${ALB_DNS} ./collect-bench-cloud.sh \
+    > results/bench2048-rooms${ROOMS}-metrics.csv \
+    2> results/bench2048-rooms${ROOMS}-collect.err &
+  COLLECT_PID=$!
+
+  NGINX_URL=wss://${CF_DNS} k6 run \
+    -e ROOMS=$ROOMS -e DURATION=2m \
+    --summary-export=results/bench2048-rooms${ROOMS}-k6.json \
+    ../load-limit/load-test-rooms.js
+
+  kill $COLLECT_PID
+  wait $COLLECT_PID 2>/dev/null
+  sleep 60
+done
+```
+
+### 7. ⚠️ production task definition 원복 (필수)
+
+**측정 끝나면 반드시 v14로 되돌리기**. PROMETHEUS_ALLOWED_CIDRS 외부 IP 노출도 자동으로 닫힘.
+
+```bash
+aws ecs update-service --region ap-northeast-2 \
+  --cluster csarena-cluster \
+  --service csarena-backend \
+  --task-definition csarena-backend:14
+
+aws ecs wait services-stable --region ap-northeast-2 \
+  --cluster csarena-cluster --services csarena-backend
+
+# 검증 — 다시 v14로 돌아왔는지
+aws ecs describe-services --region ap-northeast-2 \
+  --cluster csarena-cluster --services csarena-backend \
+  --query "services[0].taskDefinition"
+```
+
+### 8. CloudWatch에서 CPU/mem 사후 조회
+
+각 측정 시간 윈도우(예: bench-512 / ROOMS=200 측정이 14:30~14:32)를 기억해두고 메트릭 조회.
+
+```bash
+# 예시 — bench-512 / ROOMS=200 측정 윈도우
+START=2026-05-03T14:30:00Z
+END=2026-05-03T14:32:00Z
+
+# CPU
+aws cloudwatch get-metric-statistics --region ap-northeast-2 \
+  --namespace AWS/ECS \
+  --metric-name CPUUtilization \
+  --dimensions Name=ClusterName,Value=csarena-cluster Name=ServiceName,Value=csarena-backend \
+  --start-time $START --end-time $END \
+  --period 60 \
+  --statistics Average,Maximum
+
+# Memory
+aws cloudwatch get-metric-statistics --region ap-northeast-2 \
+  --namespace AWS/ECS \
+  --metric-name MemoryUtilization \
+  --dimensions Name=ClusterName,Value=csarena-cluster Name=ServiceName,Value=csarena-backend \
+  --start-time $START --end-time $END \
+  --period 60 \
+  --statistics Average,Maximum
+```
+
+각 12 측정 윈도우의 결과를 `results/bench{cpu}-rooms{N}-cw.json`으로 저장 (수동 또는 스크립트화).
+
+### 9. 분석 + doc 작성
+
+12번 분석기 그대로 재사용:
+
+```bash
+for f in results/bench*-rooms*-metrics.csv; do
+  ../load-limit/analyze-bench.sh "$f" > "${f%-metrics.csv}-summary.txt"
+done
+```
+
+각 summary + CloudWatch CPU/mem 결과를 `docs/performance/13-cloud-load-limit.md` 표에 채워 넣는다.
+
+---
+
+## 산출물 (예상)
+
+```
+results/
+  bench512-rooms{50,100,200,500}-metrics.csv     ← 사이드카 ELU 1초
+  bench512-rooms{50,100,200,500}-k6.json         ← k6 latency
+  bench512-rooms{50,100,200,500}-cw.json         ← CloudWatch CPU/mem 1분
+  bench512-rooms{50,100,200,500}-summary.txt     ← analyze-bench 출력
+  (1024, 2048도 동일)
+```
+
+## 시간 견적
+
+| 단계 | 소요 |
+|---|---|
+| 0~1. 준비 + task def 등록 | ~10분 |
+| 2~3. 시드 + 토큰 | ~10분 |
+| 4. 환경 1 (4단계 측정) | ~30분 |
+| 5. 환경 2 (4단계 측정) | ~30분 |
+| 6. 환경 3 (4단계 측정) | ~30분 |
+| 7. 원복 | 5분 |
+| 8~9. 분석 + doc | ~1시간 |
+| **합계** | **~3시간** |

--- a/scripts/benchmarks/load-limit-cloud/analyze-cloudwatch.sh
+++ b/scripts/benchmarks/load-limit-cloud/analyze-cloudwatch.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# 측정 윈도우별 CloudWatch CPU/mem 통계 표 출력
+#
+# fetch-cloudwatch.sh가 만든 results/*-cw.json에서
+# 각 측정의 CPU avg/max, mem avg/max 추출 (1분 해상도)
+#
+# 사용:
+#   ./analyze-cloudwatch.sh
+set -u
+
+cd "$(dirname "$0")"
+
+printf "%-25s %-10s %-10s %-10s %-10s\n" "FILE" "CPU avg%" "CPU max%" "MEM avg%" "MEM max%"
+printf "%-25s %-10s %-10s %-10s %-10s\n" "----" "-------" "-------" "-------" "-------"
+
+for f in results/bench512-rooms*-cw.json \
+         results/bench1024-rooms*-cw.json \
+         results/bench2048-rooms*-cw.json; do
+  if [ ! -f "$f" ]; then continue; fi
+  name=$(basename "$f" -cw.json)
+
+  cpu_avg=$(jq -r '[.cpu[].Average // 0] | if length>0 then (add/length|tostring) else "n/a" end' "$f")
+  cpu_max=$(jq -r '[.cpu[].Maximum // 0] | if length>0 then (max|tostring) else "n/a" end' "$f")
+  mem_avg=$(jq -r '[.memory[].Average // 0] | if length>0 then (add/length|tostring) else "n/a" end' "$f")
+  mem_max=$(jq -r '[.memory[].Maximum // 0] | if length>0 then (max|tostring) else "n/a" end' "$f")
+
+  # 소수점 2자리로 포맷
+  cpu_avg_f=$(printf "%.2f" "$cpu_avg" 2>/dev/null || echo "$cpu_avg")
+  cpu_max_f=$(printf "%.2f" "$cpu_max" 2>/dev/null || echo "$cpu_max")
+  mem_avg_f=$(printf "%.2f" "$mem_avg" 2>/dev/null || echo "$mem_avg")
+  mem_max_f=$(printf "%.2f" "$mem_max" 2>/dev/null || echo "$mem_max")
+
+  printf "%-25s %-10s %-10s %-10s %-10s\n" "$name" "$cpu_avg_f" "$cpu_max_f" "$mem_avg_f" "$mem_max_f"
+done

--- a/scripts/benchmarks/load-limit-cloud/analyze-cloudwatch.sh
+++ b/scripts/benchmarks/load-limit-cloud/analyze-cloudwatch.sh
@@ -24,11 +24,20 @@ for f in results/bench512-rooms*-cw.json \
   mem_avg=$(jq -r '[.memory[].Average // 0] | if length>0 then (add/length|tostring) else "n/a" end' "$f")
   mem_max=$(jq -r '[.memory[].Maximum // 0] | if length>0 then (max|tostring) else "n/a" end' "$f")
 
-  # 소수점 2자리로 포맷
-  cpu_avg_f=$(printf "%.2f" "$cpu_avg" 2>/dev/null || echo "$cpu_avg")
-  cpu_max_f=$(printf "%.2f" "$cpu_max" 2>/dev/null || echo "$cpu_max")
-  mem_avg_f=$(printf "%.2f" "$mem_avg" 2>/dev/null || echo "$mem_avg")
-  mem_max_f=$(printf "%.2f" "$mem_max" 2>/dev/null || echo "$mem_max")
+  # 숫자 검증 후 포맷 — 비숫자는 그대로 출력 (printf가 부분 출력 후 실패하면 "0.00n/a" 같은
+  # 깨진 값이 캡처돼 표 정렬이 망가지는 문제 방지)
+  format_num() {
+    local v="$1"
+    if [[ "$v" =~ ^-?[0-9]+(\.[0-9]+)?$ ]]; then
+      printf "%.2f" "$v"
+    else
+      printf "%s" "$v"
+    fi
+  }
+  cpu_avg_f=$(format_num "$cpu_avg")
+  cpu_max_f=$(format_num "$cpu_max")
+  mem_avg_f=$(format_num "$mem_avg")
+  mem_max_f=$(format_num "$mem_max")
 
   printf "%-25s %-10s %-10s %-10s %-10s\n" "$name" "$cpu_avg_f" "$cpu_max_f" "$mem_avg_f" "$mem_max_f"
 done

--- a/scripts/benchmarks/load-limit-cloud/analyze-elu.sh
+++ b/scripts/benchmarks/load-limit-cloud/analyze-elu.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# 부하 한계 측정 통합 ELU 분석기 (BSD awk 호환)
+#
+# - 사이드카 metrics.csv 12개에서 process_event_loop_utilization 추출
+# - cold start 첫 30초 제외 (컨테이너 초기 GC + JIT spike 제거)
+# - max / p99 / p95 / median 통계 출력
+#
+# 사용:
+#   ./analyze-elu.sh
+set -u
+
+cd "$(dirname "$0")"
+
+printf "%-35s %-6s %-8s %-8s %-8s %-8s\n" "FILE" "n" "max" "p99" "p95" "median"
+printf "%-35s %-6s %-8s %-8s %-8s %-8s\n" "----" "-" "---" "---" "---" "------"
+
+for f in results/bench512-rooms*-metrics.csv \
+         results/bench1024-rooms*-metrics.csv \
+         results/bench2048-rooms*-metrics.csv; do
+  if [ ! -f "$f" ]; then continue; fi
+  name=$(basename "$f" -metrics.csv)
+
+  # ELU 값만 추출 → cold start 30개 제외 → 숫자 sort → percentile 계산
+  awk -F',' '$3=="process_event_loop_utilization" {print $4}' "$f" \
+    | tail -n +31 \
+    | sort -n \
+    | awk -v name="$name" '
+        {a[NR]=$1}
+        END {
+          n = NR
+          if (n == 0) { printf "%-35s n=0 (no data)\n", name; next }
+          printf "%-35s %-6d %-8.3f %-8.3f %-8.3f %-8.3f\n",
+            name, n, a[n], a[int(n*0.99)+1], a[int(n*0.95)+1], a[int(n*0.50)+1]
+        }'
+done

--- a/scripts/benchmarks/load-limit-cloud/collect-bench-cloud.sh
+++ b/scripts/benchmarks/load-limit-cloud/collect-bench-cloud.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# 부하 한계 측정 사이드카 수집기 — Fargate 환경용 (1초 주기)
+#
+# 12번(로컬) collect-bench.sh의 클라우드 변형:
+#   - docker stats 영역 제거 → 컨테이너 CPU%/mem%는 CloudWatch에서 사후 조회
+#     (Fargate는 docker stats 동등물이 없음. 1분 해상도면 "지속" 임계 판정에 충분)
+#   - redis 영역 제거 → EC2 redis는 SG가 VPC 내부만 허용. 12번 결론상 헤드룸 충분
+#   - 단일 ALB endpoint로 통합 (production service desired_count=1)
+#
+# 사용:
+#   export ALB_URL=http://csarena-alb-xxxxxxxxxx.ap-northeast-2.elb.amazonaws.com
+#   ./collect-bench-cloud.sh > results/bench512-rooms100-metrics.csv
+#
+# 결과 분석:
+#   ../load-limit/analyze-bench.sh results/bench512-rooms100-metrics.csv
+#
+set -u
+
+if [[ -z "${ALB_URL:-}" ]]; then
+  echo "ERROR: ALB_URL 환경변수가 필요합니다 (예: http://csarena-alb-xxxx.elb.amazonaws.com)" >&2
+  exit 1
+fi
+
+METRIC_NAMES='process_event_loop_utilization|websocket_connections_active|games_active_total|game_session_leak_recovered_total|matchmaking_queue_size'
+
+# CSV 헤더 — 12번과 동일 (analyze-bench.sh 재사용 위함)
+echo "timestamp,source,metric,value"
+
+# /api/metrics 스크레이핑 — backend는 단일 인스턴스라 source는 "backend"로 고정
+prom_snapshot() {
+  local ts="$1"
+
+  curl -sS --max-time 1 "${ALB_URL}/api/metrics" 2>/dev/null \
+    | grep -E "^($METRIC_NAMES)" \
+    | awk -v ts="$ts" '{print ts",backend,"$1","$2}'
+}
+
+while true; do
+  TS=$(date +%H:%M:%S.%3N)
+  prom_snapshot "$TS"
+  sleep 1
+done

--- a/scripts/benchmarks/load-limit-cloud/fetch-cloudwatch.sh
+++ b/scripts/benchmarks/load-limit-cloud/fetch-cloudwatch.sh
@@ -1,48 +1,61 @@
 #!/bin/bash
 # 측정 윈도우별 CloudWatch CPU/MemoryUtilization 사후 조회
 #
-# windows.csv의 (prefix, rooms, start KST, end KST)에 대해
-# CloudWatch AWS/ECS 네임스페이스에서 1분 해상도 통계를 가져와
-# results/${prefix}-rooms${N}-cw.json으로 저장.
+# windows.csv의 (prefix, rooms, start, end)에 대해 CloudWatch AWS/ECS 네임스페이스에서
+# 1분 해상도 통계를 가져와 results/${prefix}-rooms${N}-cw.json으로 저장.
+#
+# windows.csv의 start/end는 ISO8601 형식(YYYY-MM-DDTHH:MM:SS+0900)으로 가정.
+# run-bench.sh가 이 형식으로 기록한다. 자정 경계 / 다른 날 재실행 충돌 방지.
 #
 # 사용:
 #   ./fetch-cloudwatch.sh
-set -u
+set -euo pipefail
 
-DATE=2026-05-03   # 측정 날짜 (필요 시 수정)
 CLUSTER=csarena-cluster
 SERVICE=csarena-backend
 REGION=ap-northeast-2
 
 cd "$(dirname "$0")"
 
-printf "%-20s %-6s %-30s %-30s\n" "PREFIX" "ROOMS" "WINDOW (KST)" "WINDOW (UTC)"
-printf "%-20s %-6s %-30s %-30s\n" "------" "-----" "-------------" "--------------"
+# KST(또는 다른 timezone) ISO8601 → UTC 변환 (BSD/GNU 호환)
+# 입력 예: 2026-05-03T14:54:31+0900
+# 출력 예: 2026-05-03T05:54:31Z
+to_utc() {
+  local iso="$1"
+  # BSD date (mac)
+  if date -j -u -f "%Y-%m-%dT%H:%M:%S%z" "$iso" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null; then
+    return
+  fi
+  # GNU date (Linux/CI)
+  date -u -d "$iso" "+%Y-%m-%dT%H:%M:%SZ"
+}
+
+printf "%-20s %-6s %-32s %-32s\n" "PREFIX" "ROOMS" "WINDOW (local)" "WINDOW (UTC)"
+printf "%-20s %-6s %-32s %-32s\n" "------" "-----" "--------------" "------------"
 
 cat results/bench512-windows.csv results/bench1024-windows.csv results/bench2048-windows.csv \
   | grep -v "^prefix" \
-  | while IFS=',' read prefix rooms start end; do
-    # KST → UTC 변환 (mac date)
-    start_utc=$(date -j -u -f "%Y-%m-%dT%H:%M:%S%z" "${DATE}T${start}+0900" "+%Y-%m-%dT%H:%M:%SZ")
-    end_utc=$(date -j -u -f "%Y-%m-%dT%H:%M:%S%z" "${DATE}T${end}+0900" "+%Y-%m-%dT%H:%M:%SZ")
+  | while IFS=',' read -r prefix rooms start end; do
+    start_utc=$(to_utc "$start")
+    end_utc=$(to_utc "$end")
 
-    printf "%-20s %-6s %-30s %-30s\n" \
+    printf "%-20s %-6s %-32s %-32s\n" \
       "$prefix" "$rooms" "${start} ~ ${end}" "${start_utc} ~ ${end_utc}"
 
-    cpu=$(aws cloudwatch get-metric-statistics --region $REGION \
+    cpu=$(aws cloudwatch get-metric-statistics --region "$REGION" \
       --namespace AWS/ECS \
       --metric-name CPUUtilization \
-      --dimensions Name=ClusterName,Value=$CLUSTER Name=ServiceName,Value=$SERVICE \
+      --dimensions "Name=ClusterName,Value=$CLUSTER" "Name=ServiceName,Value=$SERVICE" \
       --start-time "$start_utc" --end-time "$end_utc" \
       --period 60 \
       --statistics Average Maximum \
       --query "Datapoints | sort_by(@, &Timestamp)" \
       --output json)
 
-    mem=$(aws cloudwatch get-metric-statistics --region $REGION \
+    mem=$(aws cloudwatch get-metric-statistics --region "$REGION" \
       --namespace AWS/ECS \
       --metric-name MemoryUtilization \
-      --dimensions Name=ClusterName,Value=$CLUSTER Name=ServiceName,Value=$SERVICE \
+      --dimensions "Name=ClusterName,Value=$CLUSTER" "Name=ServiceName,Value=$SERVICE" \
       --start-time "$start_utc" --end-time "$end_utc" \
       --period 60 \
       --statistics Average Maximum \

--- a/scripts/benchmarks/load-limit-cloud/fetch-cloudwatch.sh
+++ b/scripts/benchmarks/load-limit-cloud/fetch-cloudwatch.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# 측정 윈도우별 CloudWatch CPU/MemoryUtilization 사후 조회
+#
+# windows.csv의 (prefix, rooms, start KST, end KST)에 대해
+# CloudWatch AWS/ECS 네임스페이스에서 1분 해상도 통계를 가져와
+# results/${prefix}-rooms${N}-cw.json으로 저장.
+#
+# 사용:
+#   ./fetch-cloudwatch.sh
+set -u
+
+DATE=2026-05-03   # 측정 날짜 (필요 시 수정)
+CLUSTER=csarena-cluster
+SERVICE=csarena-backend
+REGION=ap-northeast-2
+
+cd "$(dirname "$0")"
+
+printf "%-20s %-6s %-30s %-30s\n" "PREFIX" "ROOMS" "WINDOW (KST)" "WINDOW (UTC)"
+printf "%-20s %-6s %-30s %-30s\n" "------" "-----" "-------------" "--------------"
+
+cat results/bench512-windows.csv results/bench1024-windows.csv results/bench2048-windows.csv \
+  | grep -v "^prefix" \
+  | while IFS=',' read prefix rooms start end; do
+    # KST → UTC 변환 (mac date)
+    start_utc=$(date -j -u -f "%Y-%m-%dT%H:%M:%S%z" "${DATE}T${start}+0900" "+%Y-%m-%dT%H:%M:%SZ")
+    end_utc=$(date -j -u -f "%Y-%m-%dT%H:%M:%S%z" "${DATE}T${end}+0900" "+%Y-%m-%dT%H:%M:%SZ")
+
+    printf "%-20s %-6s %-30s %-30s\n" \
+      "$prefix" "$rooms" "${start} ~ ${end}" "${start_utc} ~ ${end_utc}"
+
+    cpu=$(aws cloudwatch get-metric-statistics --region $REGION \
+      --namespace AWS/ECS \
+      --metric-name CPUUtilization \
+      --dimensions Name=ClusterName,Value=$CLUSTER Name=ServiceName,Value=$SERVICE \
+      --start-time "$start_utc" --end-time "$end_utc" \
+      --period 60 \
+      --statistics Average Maximum \
+      --query "Datapoints | sort_by(@, &Timestamp)" \
+      --output json)
+
+    mem=$(aws cloudwatch get-metric-statistics --region $REGION \
+      --namespace AWS/ECS \
+      --metric-name MemoryUtilization \
+      --dimensions Name=ClusterName,Value=$CLUSTER Name=ServiceName,Value=$SERVICE \
+      --start-time "$start_utc" --end-time "$end_utc" \
+      --period 60 \
+      --statistics Average Maximum \
+      --query "Datapoints | sort_by(@, &Timestamp)" \
+      --output json)
+
+    jq -n --argjson cpu "$cpu" --argjson mem "$mem" \
+      '{cpu: $cpu, memory: $mem}' \
+      > "results/${prefix}-rooms${rooms}-cw.json"
+  done
+
+echo ""
+echo "=== CloudWatch 데이터 저장 완료 ==="
+ls -la results/*-cw.json

--- a/scripts/benchmarks/load-limit-cloud/run-bench.sh
+++ b/scripts/benchmarks/load-limit-cloud/run-bench.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# 부하 한계 측정 자동화 — 한 환경(cpu)에서 4단계 룸 수 자동 측정
+#
+# 사용:
+#   ./run-bench.sh 512    # Fargate 0.5 vCPU
+#   ./run-bench.sh 1024   # Fargate 1 vCPU
+#   ./run-bench.sh 2048   # Fargate 2 vCPU
+#
+# 결과:
+#   results/bench${cpu}-rooms${N}-metrics.csv   ← 사이드카 1초 폴링
+#   results/bench${cpu}-rooms${N}-k6.json       ← k6 summary
+#   results/bench${cpu}-rooms${N}-collect.err   ← 사이드카 stderr
+#   results/bench${cpu}-windows.csv             ← 측정 시간 윈도우 (CloudWatch 사후 조회용)
+#
+# 전제 조건:
+#   - service가 csarena-backend-bench-${cpu} task definition으로 deploy 완료
+#   - tokens.json이 ../websocket-multi-instance/에 있음
+#   - PROMETHEUS_ALLOWED_CIDRS에 측정 호스트 공인 IP 포함
+#   - k6 설치
+set -u
+
+CPU=${1:?"usage: $0 <cpu> (512|1024|2048)"}
+PREFIX="bench${CPU}"
+
+ALB_DNS=csarena-alb-330901287.ap-northeast-2.elb.amazonaws.com
+CF_DNS=dm2twkzzyg6a9.cloudfront.net
+
+mkdir -p results
+
+# 측정 시간 윈도우 헤더 (덮어쓰기)
+echo "prefix,rooms,start,end" > "results/${PREFIX}-windows.csv"
+
+for ROOMS in 50 100 200 500; do
+  TS_START=$(date +%H:%M:%S)
+  echo ""
+  echo "=========================================="
+  echo "=== $PREFIX / ROOMS=$ROOMS / start: $TS_START"
+  echo "=========================================="
+
+  # 사이드카 백그라운드 — /api/metrics 1초 폴링
+  ALB_URL=http://$ALB_DNS ./collect-bench-cloud.sh \
+    > "results/${PREFIX}-rooms${ROOMS}-metrics.csv" \
+    2> "results/${PREFIX}-rooms${ROOMS}-collect.err" &
+  COLLECT_PID=$!
+
+  # k6 부하 (CloudFront → ALB → Fargate task)
+  k6 run \
+    -e ROOMS="$ROOMS" -e DURATION=2m -e NGINX_URL="wss://$CF_DNS" \
+    --summary-export="results/${PREFIX}-rooms${ROOMS}-k6.json" \
+    ../load-limit/load-test-rooms.js
+
+  # 사이드카 종료
+  kill "$COLLECT_PID" 2>/dev/null
+  wait "$COLLECT_PID" 2>/dev/null
+
+  TS_END=$(date +%H:%M:%S)
+  echo "=== $PREFIX / ROOMS=$ROOMS / end: $TS_END"
+  echo "${PREFIX},${ROOMS},${TS_START},${TS_END}" >> "results/${PREFIX}-windows.csv"
+
+  # 다음 단계 전 안정화 (active 룸 cleanup, gc 안정)
+  if [ "$ROOMS" != "500" ]; then
+    echo "다음 단계 전 60초 대기..."
+    sleep 60
+  fi
+done
+
+echo ""
+echo "=========================================="
+echo "=== $PREFIX 4단계 측정 완료"
+echo "=========================================="
+ls -la results/${PREFIX}-*.csv results/${PREFIX}-*.json 2>/dev/null

--- a/scripts/benchmarks/load-limit-cloud/run-bench.sh
+++ b/scripts/benchmarks/load-limit-cloud/run-bench.sh
@@ -11,13 +11,19 @@
 #   results/bench${cpu}-rooms${N}-k6.json       ← k6 summary
 #   results/bench${cpu}-rooms${N}-collect.err   ← 사이드카 stderr
 #   results/bench${cpu}-windows.csv             ← 측정 시간 윈도우 (CloudWatch 사후 조회용)
+#                                                 start/end는 ISO8601 (YYYY-MM-DDTHH:MM:SS+TZ)
+#                                                 — 자정 경계/다른 날 재실행 충돌 방지
+#
+# 동작 보장:
+#   - set -euo pipefail로 에러 시 즉시 중단 (k6 thresholds 실패 99는 제외 — 측정은 유효)
+#   - trap EXIT/INT/TERM으로 collector 좀비 차단
 #
 # 전제 조건:
 #   - service가 csarena-backend-bench-${cpu} task definition으로 deploy 완료
 #   - tokens.json이 ../websocket-multi-instance/에 있음
 #   - PROMETHEUS_ALLOWED_CIDRS에 측정 호스트 공인 IP 포함
 #   - k6 설치
-set -u
+set -euo pipefail
 
 CPU=${1:?"usage: $0 <cpu> (512|1024|2048)"}
 PREFIX="bench${CPU}"
@@ -25,13 +31,25 @@ PREFIX="bench${CPU}"
 ALB_DNS=csarena-alb-330901287.ap-northeast-2.elb.amazonaws.com
 CF_DNS=dm2twkzzyg6a9.cloudfront.net
 
+cd "$(dirname "$0")"
 mkdir -p results
 
-# 측정 시간 윈도우 헤더 (덮어쓰기)
+# Collector cleanup — INT/TERM/EXIT 모두에서 좀비 방지
+COLLECT_PID=""
+cleanup() {
+  if [[ -n "$COLLECT_PID" ]]; then
+    kill "$COLLECT_PID" 2>/dev/null || true
+    wait "$COLLECT_PID" 2>/dev/null || true
+    COLLECT_PID=""
+  fi
+}
+trap cleanup EXIT INT TERM
+
+# 측정 시간 윈도우 헤더 (덮어쓰기) — start/end는 ISO8601 with timezone
 echo "prefix,rooms,start,end" > "results/${PREFIX}-windows.csv"
 
 for ROOMS in 50 100 200 500; do
-  TS_START=$(date +%H:%M:%S)
+  TS_START=$(date +"%Y-%m-%dT%H:%M:%S%z")
   echo ""
   echo "=========================================="
   echo "=== $PREFIX / ROOMS=$ROOMS / start: $TS_START"
@@ -43,18 +61,26 @@ for ROOMS in 50 100 200 500; do
     2> "results/${PREFIX}-rooms${ROOMS}-collect.err" &
   COLLECT_PID=$!
 
-  # k6 부하 (CloudFront → ALB → Fargate task)
+  # k6 부하 — exit code 처리:
+  #   0  = 모든 thresholds 통과
+  #   99 = thresholds 일부 실패 (그러나 시나리오 정상 완료 — 측정은 유효)
+  #   그 외 = 실제 에러 (네트워크, 스크립트 결함 등) → 중단
+  k6_exit=0
   k6 run \
     -e ROOMS="$ROOMS" -e DURATION=2m -e NGINX_URL="wss://$CF_DNS" \
     --summary-export="results/${PREFIX}-rooms${ROOMS}-k6.json" \
-    ../load-limit/load-test-rooms.js
+    ../load-limit/load-test-rooms.js || k6_exit=$?
 
-  # 사이드카 종료
-  kill "$COLLECT_PID" 2>/dev/null
-  wait "$COLLECT_PID" 2>/dev/null
+  # 사이드카 종료 (정상/에러 양 경로)
+  cleanup
 
-  TS_END=$(date +%H:%M:%S)
-  echo "=== $PREFIX / ROOMS=$ROOMS / end: $TS_END"
+  if [[ "$k6_exit" -ne 0 && "$k6_exit" -ne 99 ]]; then
+    echo "ERROR: k6 unexpected exit code $k6_exit for $PREFIX rooms=$ROOMS — 배치 중단" >&2
+    exit "$k6_exit"
+  fi
+
+  TS_END=$(date +"%Y-%m-%dT%H:%M:%S%z")
+  echo "=== $PREFIX / ROOMS=$ROOMS / end: $TS_END (k6 exit=$k6_exit)"
   echo "${PREFIX},${ROOMS},${TS_START},${TS_END}" >> "results/${PREFIX}-windows.csv"
 
   # 다음 단계 전 안정화 (active 룸 cleanup, gc 안정)
@@ -68,4 +94,4 @@ echo ""
 echo "=========================================="
 echo "=== $PREFIX 4단계 측정 완료"
 echo "=========================================="
-ls -la results/${PREFIX}-*.csv results/${PREFIX}-*.json 2>/dev/null
+ls -la "results/${PREFIX}-"*.csv "results/${PREFIX}-"*.json 2>/dev/null

--- a/scripts/benchmarks/load-limit-cloud/sign-bench-tokens-cloud.mjs
+++ b/scripts/benchmarks/load-limit-cloud/sign-bench-tokens-cloud.mjs
@@ -40,8 +40,8 @@ function validateIdentifier(name, value) {
 }
 
 // 임의 문자열을 single-quoted shell literal로 안전하게 escape
-// 예: csarena123!@# → 'csarena123!@#'
-//     it's a → 'it'\''s a'
+// 예: hello world → 'hello world'
+//     it's a      → 'it'\''s a'
 function shellQuote(value) {
   return "'" + String(value).replace(/'/g, "'\\''") + "'";
 }

--- a/scripts/benchmarks/load-limit-cloud/sign-bench-tokens-cloud.mjs
+++ b/scripts/benchmarks/load-limit-cloud/sign-bench-tokens-cloud.mjs
@@ -20,7 +20,7 @@
  */
 import jwt from 'jsonwebtoken';
 import { writeFileSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 function requireEnv(name) {
   const v = process.env[name];
@@ -31,6 +31,21 @@ function requireEnv(name) {
   return v;
 }
 
+// 식별자(컨테이너명, DB 사용자/이름) shell 주입 차단 — 영숫자·하이픈·언더스코어만 허용
+function validateIdentifier(name, value) {
+  if (!/^[a-zA-Z0-9_-]+$/.test(value)) {
+    console.error(`ERROR: ${name}에 허용되지 않은 문자 포함: ${value}`);
+    process.exit(1);
+  }
+}
+
+// 임의 문자열을 single-quoted shell literal로 안전하게 escape
+// 예: csarena123!@# → 'csarena123!@#'
+//     it's a → 'it'\''s a'
+function shellQuote(value) {
+  return "'" + String(value).replace(/'/g, "'\\''") + "'";
+}
+
 const SECRET = requireEnv('JWT_SECRET');
 const DB_PASSWORD = requireEnv('DB_PASSWORD');
 const SSH_KEY = process.env.SSH_KEY || '~/Downloads/csarena.pem';
@@ -39,14 +54,30 @@ const PG_CONTAINER = process.env.PG_CONTAINER || 'csarena-postgres';
 const DB_USER = process.env.DB_USER || 'csarena';
 const DB_NAME = process.env.DB_NAME || 'csarena';
 
-// SSH 한 번에 전체 결과 받기
-const sshCmd = `ssh -i ${SSH_KEY} -o StrictHostKeyChecking=no ${EC2_HOST} ` +
-  `"docker exec -e PGPASSWORD='${DB_PASSWORD}' ${PG_CONTAINER} ` +
+validateIdentifier('PG_CONTAINER', PG_CONTAINER);
+validateIdentifier('DB_USER', DB_USER);
+validateIdentifier('DB_NAME', DB_NAME);
+
+// Remote command — DB_PASSWORD는 shellQuote로 escape (single quote/특수문자 안전).
+// SQL은 fixed literal (사용자 입력 없음).
+const remoteCmd =
+  `docker exec -e PGPASSWORD=${shellQuote(DB_PASSWORD)} ${PG_CONTAINER} ` +
   `psql -U ${DB_USER} -d ${DB_NAME} -t -A -F'|' -c ` +
-  `\\"SELECT id, nickname, oauth_id FROM users WHERE oauth_id LIKE 'dev-benchuser%' ORDER BY id\\""`;
+  `"SELECT id, nickname, oauth_id FROM users WHERE oauth_id LIKE 'dev-benchuser%' ORDER BY id"`;
+
+// execFileSync + 인자 배열로 ssh 실행 — 로컬 shell 주입 위험 차단.
+// StrictHostKeyChecking=accept-new: 첫 접속 시 호스트 키 자동 등록(TOFU),
+//   이후 변경 감지. =no(완전 무시)와 달리 MITM 일부 방어.
+const sshArgs = [
+  '-i', SSH_KEY,
+  '-o', 'StrictHostKeyChecking=accept-new',
+  '-o', 'BatchMode=yes',
+  EC2_HOST,
+  remoteCmd,
+];
 
 console.error(`Querying users via SSH...`);
-const raw = execSync(sshCmd, { encoding: 'utf8' }).trim();
+const raw = execFileSync('ssh', sshArgs, { encoding: 'utf8' }).trim();
 const rows = raw.split('\n').filter(Boolean);
 
 if (rows.length === 0) {

--- a/scripts/benchmarks/load-limit-cloud/sign-bench-tokens-cloud.mjs
+++ b/scripts/benchmarks/load-limit-cloud/sign-bench-tokens-cloud.mjs
@@ -1,0 +1,72 @@
+/**
+ * 부하 한계 측정용 JWT 일괄 발급 — Fargate 환경 (EC2 PG via SSH)
+ *
+ * sign-bench-tokens.mjs(로컬 docker 가정)의 클라우드 변형.
+ * SSH로 EC2의 csarena-postgres 컨테이너에 접근해 dev-benchuser% 유저 조회.
+ *
+ * 사용 (필수 env):
+ *   JWT_SECRET='<production JWT_SECRET>' \
+ *     DB_PASSWORD='<production DB_PASSWORD>' \
+ *     SSH_KEY=~/Downloads/csarena.pem \
+ *     EC2_HOST=ubuntu@13.125.237.251 \
+ *     PG_CONTAINER=csarena-postgres \
+ *     DB_USER=csarena DB_NAME=csarena \
+ *     node sign-bench-tokens-cloud.mjs
+ *
+ * production secrets는 task definition v17에서 받아 export — 코드/메모에 적지 말 것.
+ *
+ * 출력: ./tokens.json (load-test-rooms.js가 ../websocket-multi-instance/tokens.json을
+ *       참조하므로, 측정 호스트에서 두 파일이 동일하도록 복사 필요)
+ */
+import jwt from 'jsonwebtoken';
+import { writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`ERROR: ${name} 환경변수가 필요합니다. production 값으로 export 후 재실행.`);
+    process.exit(1);
+  }
+  return v;
+}
+
+const SECRET = requireEnv('JWT_SECRET');
+const DB_PASSWORD = requireEnv('DB_PASSWORD');
+const SSH_KEY = process.env.SSH_KEY || '~/Downloads/csarena.pem';
+const EC2_HOST = process.env.EC2_HOST || 'ubuntu@13.125.237.251';
+const PG_CONTAINER = process.env.PG_CONTAINER || 'csarena-postgres';
+const DB_USER = process.env.DB_USER || 'csarena';
+const DB_NAME = process.env.DB_NAME || 'csarena';
+
+// SSH 한 번에 전체 결과 받기
+const sshCmd = `ssh -i ${SSH_KEY} -o StrictHostKeyChecking=no ${EC2_HOST} ` +
+  `"docker exec -e PGPASSWORD='${DB_PASSWORD}' ${PG_CONTAINER} ` +
+  `psql -U ${DB_USER} -d ${DB_NAME} -t -A -F'|' -c ` +
+  `\\"SELECT id, nickname, oauth_id FROM users WHERE oauth_id LIKE 'dev-benchuser%' ORDER BY id\\""`;
+
+console.error(`Querying users via SSH...`);
+const raw = execSync(sshCmd, { encoding: 'utf8' }).trim();
+const rows = raw.split('\n').filter(Boolean);
+
+if (rows.length === 0) {
+  console.error('ERROR: dev-benchuser% 유저를 찾을 수 없습니다. 시드 SQL을 먼저 실행하세요.');
+  process.exit(1);
+}
+
+console.error(`Found ${rows.length} bench users. Signing tokens...`);
+
+const tokens = [];
+for (const row of rows) {
+  const [id, nickname, oauthId] = row.split('|');
+  const token = jwt.sign(
+    { sub: Number(id), visibleId: oauthId, nickname, oauthProvider: 'github' },
+    SECRET,
+    { expiresIn: '4h' },  // 12회 측정 + 분석 시간 고려해 4시간
+  );
+  tokens.push({ userId: Number(id), nickname, token });
+}
+
+const outPath = new URL('./tokens.json', import.meta.url);
+writeFileSync(outPath, JSON.stringify(tokens, null, 2));
+console.log(`Wrote ${tokens.length} tokens to ${outPath.pathname}`);

--- a/scripts/benchmarks/load-limit-cloud/task-definitions/bench-1024.json
+++ b/scripts/benchmarks/load-limit-cloud/task-definitions/bench-1024.json
@@ -1,0 +1,69 @@
+{
+  "family": "csarena-backend-bench-1024",
+  "executionRoleArn": "arn:aws:iam::733959200078:role/ecsTaskExecutionRole",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "1024",
+  "memory": "2048",
+  "containerDefinitions": [
+    {
+      "name": "backend",
+      "image": "733959200078.dkr.ecr.ap-northeast-2.amazonaws.com/csarena-backend:v8",
+      "cpu": 0,
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 4000,
+          "hostPort": 4000,
+          "protocol": "tcp",
+          "name": "backend-4000-tcp",
+          "appProtocol": "http"
+        }
+      ],
+      "environment": [
+        { "name": "NODE_ENV", "value": "production" },
+        { "name": "DB_HOST", "value": "172.31.44.173" },
+        { "name": "DB_PORT", "value": "5432" },
+        { "name": "DB_USERNAME", "value": "csarena" },
+        { "name": "DB_PASSWORD", "value": "REPLACE_WITH_PRODUCTION_DB_PASSWORD" },
+        { "name": "DB_DATABASE", "value": "csarena" },
+        { "name": "REDIS_HOST", "value": "172.31.44.173" },
+        { "name": "REDIS_PORT", "value": "6379" },
+        { "name": "REDIS_PASSWORD", "value": "REPLACE_WITH_PRODUCTION_REDIS_PASSWORD" },
+        { "name": "JWT_SECRET", "value": "REPLACE_WITH_PRODUCTION_JWT_SECRET" },
+        { "name": "JWT_REFRESH_SECRET", "value": "REPLACE_WITH_PRODUCTION_JWT_REFRESH_SECRET" },
+        { "name": "GITHUB_CLIENT_ID", "value": "REPLACE_WITH_GITHUB_CLIENT_ID" },
+        { "name": "GITHUB_CLIENT_SECRET", "value": "REPLACE_WITH_GITHUB_CLIENT_SECRET" },
+        { "name": "GITHUB_CALLBACK_URL", "value": "https://dm2twkzzyg6a9.cloudfront.net/api/auth/github/callback" },
+        { "name": "CORS_ORIGIN", "value": "https://dm2twkzzyg6a9.cloudfront.net" },
+        { "name": "FRONTEND_URL", "value": "https://dm2twkzzyg6a9.cloudfront.net" },
+        { "name": "GRADING_MODE", "value": "mock" },
+        { "name": "CLOVA_STUDIO_API_KEY", "value": "1" },
+        { "name": "BENCH_GRADING_BYPASS", "value": "true" },
+        { "name": "PROMETHEUS_ALLOWED_CIDRS", "value": "172.0.0.0/8,REPLACE_WITH_BENCH_HOST_PUBLIC_IP/32" }
+      ],
+      "environmentFiles": [],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "ulimits": [],
+      "systemControls": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/csarena-backend-bench",
+          "awslogs-create-group": "true",
+          "awslogs-region": "ap-northeast-2",
+          "awslogs-stream-prefix": "ecs"
+        },
+        "secretOptions": []
+      },
+      "healthCheck": {
+        "command": ["CMD-SHELL", "wget -qO- http://localhost:4000/api/health || exit 1"],
+        "interval": 30,
+        "timeout": 10,
+        "retries": 3,
+        "startPeriod": 60
+      }
+    }
+  ]
+}

--- a/scripts/benchmarks/load-limit-cloud/task-definitions/bench-1024.json
+++ b/scripts/benchmarks/load-limit-cloud/task-definitions/bench-1024.json
@@ -40,7 +40,7 @@
         { "name": "GRADING_MODE", "value": "mock" },
         { "name": "CLOVA_STUDIO_API_KEY", "value": "1" },
         { "name": "BENCH_GRADING_BYPASS", "value": "true" },
-        { "name": "PROMETHEUS_ALLOWED_CIDRS", "value": "172.0.0.0/8,REPLACE_WITH_BENCH_HOST_PUBLIC_IP/32" }
+        { "name": "PROMETHEUS_ALLOWED_CIDRS", "value": "172.16.0.0/12,REPLACE_WITH_BENCH_HOST_PUBLIC_IP/32" }
       ],
       "environmentFiles": [],
       "mountPoints": [],

--- a/scripts/benchmarks/load-limit-cloud/task-definitions/bench-2048.json
+++ b/scripts/benchmarks/load-limit-cloud/task-definitions/bench-2048.json
@@ -1,0 +1,69 @@
+{
+  "family": "csarena-backend-bench-2048",
+  "executionRoleArn": "arn:aws:iam::733959200078:role/ecsTaskExecutionRole",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "2048",
+  "memory": "4096",
+  "containerDefinitions": [
+    {
+      "name": "backend",
+      "image": "733959200078.dkr.ecr.ap-northeast-2.amazonaws.com/csarena-backend:v8",
+      "cpu": 0,
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 4000,
+          "hostPort": 4000,
+          "protocol": "tcp",
+          "name": "backend-4000-tcp",
+          "appProtocol": "http"
+        }
+      ],
+      "environment": [
+        { "name": "NODE_ENV", "value": "production" },
+        { "name": "DB_HOST", "value": "172.31.44.173" },
+        { "name": "DB_PORT", "value": "5432" },
+        { "name": "DB_USERNAME", "value": "csarena" },
+        { "name": "DB_PASSWORD", "value": "REPLACE_WITH_PRODUCTION_DB_PASSWORD" },
+        { "name": "DB_DATABASE", "value": "csarena" },
+        { "name": "REDIS_HOST", "value": "172.31.44.173" },
+        { "name": "REDIS_PORT", "value": "6379" },
+        { "name": "REDIS_PASSWORD", "value": "REPLACE_WITH_PRODUCTION_REDIS_PASSWORD" },
+        { "name": "JWT_SECRET", "value": "REPLACE_WITH_PRODUCTION_JWT_SECRET" },
+        { "name": "JWT_REFRESH_SECRET", "value": "REPLACE_WITH_PRODUCTION_JWT_REFRESH_SECRET" },
+        { "name": "GITHUB_CLIENT_ID", "value": "REPLACE_WITH_GITHUB_CLIENT_ID" },
+        { "name": "GITHUB_CLIENT_SECRET", "value": "REPLACE_WITH_GITHUB_CLIENT_SECRET" },
+        { "name": "GITHUB_CALLBACK_URL", "value": "https://dm2twkzzyg6a9.cloudfront.net/api/auth/github/callback" },
+        { "name": "CORS_ORIGIN", "value": "https://dm2twkzzyg6a9.cloudfront.net" },
+        { "name": "FRONTEND_URL", "value": "https://dm2twkzzyg6a9.cloudfront.net" },
+        { "name": "GRADING_MODE", "value": "mock" },
+        { "name": "CLOVA_STUDIO_API_KEY", "value": "1" },
+        { "name": "BENCH_GRADING_BYPASS", "value": "true" },
+        { "name": "PROMETHEUS_ALLOWED_CIDRS", "value": "172.0.0.0/8,REPLACE_WITH_BENCH_HOST_PUBLIC_IP/32" }
+      ],
+      "environmentFiles": [],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "ulimits": [],
+      "systemControls": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/csarena-backend-bench",
+          "awslogs-create-group": "true",
+          "awslogs-region": "ap-northeast-2",
+          "awslogs-stream-prefix": "ecs"
+        },
+        "secretOptions": []
+      },
+      "healthCheck": {
+        "command": ["CMD-SHELL", "wget -qO- http://localhost:4000/api/health || exit 1"],
+        "interval": 30,
+        "timeout": 10,
+        "retries": 3,
+        "startPeriod": 60
+      }
+    }
+  ]
+}

--- a/scripts/benchmarks/load-limit-cloud/task-definitions/bench-2048.json
+++ b/scripts/benchmarks/load-limit-cloud/task-definitions/bench-2048.json
@@ -40,7 +40,7 @@
         { "name": "GRADING_MODE", "value": "mock" },
         { "name": "CLOVA_STUDIO_API_KEY", "value": "1" },
         { "name": "BENCH_GRADING_BYPASS", "value": "true" },
-        { "name": "PROMETHEUS_ALLOWED_CIDRS", "value": "172.0.0.0/8,REPLACE_WITH_BENCH_HOST_PUBLIC_IP/32" }
+        { "name": "PROMETHEUS_ALLOWED_CIDRS", "value": "172.16.0.0/12,REPLACE_WITH_BENCH_HOST_PUBLIC_IP/32" }
       ],
       "environmentFiles": [],
       "mountPoints": [],

--- a/scripts/benchmarks/load-limit-cloud/task-definitions/bench-512.json
+++ b/scripts/benchmarks/load-limit-cloud/task-definitions/bench-512.json
@@ -40,7 +40,7 @@
         { "name": "GRADING_MODE", "value": "mock" },
         { "name": "CLOVA_STUDIO_API_KEY", "value": "1" },
         { "name": "BENCH_GRADING_BYPASS", "value": "true" },
-        { "name": "PROMETHEUS_ALLOWED_CIDRS", "value": "172.0.0.0/8,REPLACE_WITH_BENCH_HOST_PUBLIC_IP/32" }
+        { "name": "PROMETHEUS_ALLOWED_CIDRS", "value": "172.16.0.0/12,REPLACE_WITH_BENCH_HOST_PUBLIC_IP/32" }
       ],
       "environmentFiles": [],
       "mountPoints": [],

--- a/scripts/benchmarks/load-limit-cloud/task-definitions/bench-512.json
+++ b/scripts/benchmarks/load-limit-cloud/task-definitions/bench-512.json
@@ -1,0 +1,69 @@
+{
+  "family": "csarena-backend-bench-512",
+  "executionRoleArn": "arn:aws:iam::733959200078:role/ecsTaskExecutionRole",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "512",
+  "memory": "1024",
+  "containerDefinitions": [
+    {
+      "name": "backend",
+      "image": "733959200078.dkr.ecr.ap-northeast-2.amazonaws.com/csarena-backend:v8",
+      "cpu": 0,
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 4000,
+          "hostPort": 4000,
+          "protocol": "tcp",
+          "name": "backend-4000-tcp",
+          "appProtocol": "http"
+        }
+      ],
+      "environment": [
+        { "name": "NODE_ENV", "value": "production" },
+        { "name": "DB_HOST", "value": "172.31.44.173" },
+        { "name": "DB_PORT", "value": "5432" },
+        { "name": "DB_USERNAME", "value": "csarena" },
+        { "name": "DB_PASSWORD", "value": "REPLACE_WITH_PRODUCTION_DB_PASSWORD" },
+        { "name": "DB_DATABASE", "value": "csarena" },
+        { "name": "REDIS_HOST", "value": "172.31.44.173" },
+        { "name": "REDIS_PORT", "value": "6379" },
+        { "name": "REDIS_PASSWORD", "value": "REPLACE_WITH_PRODUCTION_REDIS_PASSWORD" },
+        { "name": "JWT_SECRET", "value": "REPLACE_WITH_PRODUCTION_JWT_SECRET" },
+        { "name": "JWT_REFRESH_SECRET", "value": "REPLACE_WITH_PRODUCTION_JWT_REFRESH_SECRET" },
+        { "name": "GITHUB_CLIENT_ID", "value": "REPLACE_WITH_GITHUB_CLIENT_ID" },
+        { "name": "GITHUB_CLIENT_SECRET", "value": "REPLACE_WITH_GITHUB_CLIENT_SECRET" },
+        { "name": "GITHUB_CALLBACK_URL", "value": "https://dm2twkzzyg6a9.cloudfront.net/api/auth/github/callback" },
+        { "name": "CORS_ORIGIN", "value": "https://dm2twkzzyg6a9.cloudfront.net" },
+        { "name": "FRONTEND_URL", "value": "https://dm2twkzzyg6a9.cloudfront.net" },
+        { "name": "GRADING_MODE", "value": "mock" },
+        { "name": "CLOVA_STUDIO_API_KEY", "value": "1" },
+        { "name": "BENCH_GRADING_BYPASS", "value": "true" },
+        { "name": "PROMETHEUS_ALLOWED_CIDRS", "value": "172.0.0.0/8,REPLACE_WITH_BENCH_HOST_PUBLIC_IP/32" }
+      ],
+      "environmentFiles": [],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "ulimits": [],
+      "systemControls": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/csarena-backend-bench",
+          "awslogs-create-group": "true",
+          "awslogs-region": "ap-northeast-2",
+          "awslogs-stream-prefix": "ecs"
+        },
+        "secretOptions": []
+      },
+      "healthCheck": {
+        "command": ["CMD-SHELL", "wget -qO- http://localhost:4000/api/health || exit 1"],
+        "interval": 30,
+        "timeout": 10,
+        "retries": 3,
+        "startPeriod": 60
+      }
+    }
+  ]
+}


### PR DESCRIPTION
  ## 📝 개요 (Description)

  12번 로컬 부하 측정의 후속으로, **AWS ECS Fargate 환경에서 vCPU별 동시 게임 룸
  한계를 측정**하기 위한 재현 가능한 자동화 자산을
  `scripts/benchmarks/load-limit-cloud/`에 추가합니다.

  12번 측정의 가장 큰 약점이었던 "M3 Pro 단일 호스트 + macOS 스케줄러 + Docker
  Desktop 가상화" 환경 효과를 정면으로 메우고, 12번에서 발견한 vCPU 1→2
  superlinear 패턴이 클라우드에서도 재현되는지 검증할 수 있게 됩니다.

  **측정 결과 요약 (2026-05-03 실행, 결과 doc은 wiki 반영 —
  `docs/performance/13-cloud-load-limit.md`):**

  | 환경 | ELU p95 한계 도달 | 한계 룸 수 |
  |---|---|---|
  | Fargate 0.5 vCPU / 1 GB | 0.896 (100룸) | **100 룸** |
  | Fargate 1 vCPU / 2 GB | 미도달 (500룸 0.756) | **500 룸+ 미도달** |
  | Fargate 2 vCPU / 4 GB | 미도달 (500룸 0.260) | **사실상 idle** |

  핵심 발견:
  1. 12번 cpus:1 한계(100 룸) → Fargate 0.5 vCPU에서 **정확히 재현**
  2. vCPU 1→2 superlinear 패턴이 Fargate에서 **더 강하게 재현**
  3. 같은 "1 코어" 제약에서 Fargate가 로컬 docker보다 **5배 처리량** — 가상화
  overhead 정량화

  **추가 자산 구성:**
  - `task-definitions/bench-{512,1024,2048}.json` — Fargate vCPU별 BENCH task
  definition (secrets는 placeholder, 사용자가 production 값 주입)
  - `run-bench.sh <cpu>` — 한 환경 4단계 부하 자동 실행
  - `collect-bench-cloud.sh` — `/api/metrics` 1초 폴링 사이드카 (12번 사이드카의
  클라우드 변형)
  - `sign-bench-tokens-cloud.mjs` — SSH 통한 EC2 PG 1000명 토큰 발급
  - `analyze-elu.sh` / `fetch-cloudwatch.sh` / `analyze-cloudwatch.sh` — 결과
  분석기
  - `README.md` — runbook (사전 준비 → task def 등록 → service 일시 교체 → 12회
  측정 → 원복 → 분석)

  ## 🔗 관련 이슈 (Related Issues)

  -   Closes #293

  ## 🏷️작업 유형 (Type of Change)

  -   [ ] ✨ 기능 추가 (New Feature)
  -   [ ] 🐛 버그 수정 (Bug Fix)
  -   [ ] ♻️ 리팩토링 (Refactoring)
  -   [ ] 📝 문서 업데이트 (Documentation)
  -   [x] 🔧 설정 변경 및 기타 (Config & Other)

  ## ✅ 체크리스트 (Checklist)

  -   [ ] 코드가 정상적으로 컴파일/빌드 되나요?
  -   [ ] 기존 테스트를 통과했나요? (새로운 테스트가 필요하다면 추가했나요?)
  -   [ ] 스스로 코드를 리뷰했나요? (Self-review)
  -   [ ] 불필요한 주석이나 디버깅 코드는 제거했나요?
  -   [ ] 문서(README 등)에 변경 사항을 업데이트했나요?

  ## 📸 스크린샷 (Screenshots)

  UI 변경 없음.

  ## 🎸 기타 (Etc)

  **보안 처리:**
  - task definition JSON 3종의 secrets(`DB_PASSWORD`, `JWT_SECRET`,
  `JWT_REFRESH_SECRET`, `REDIS_PASSWORD`, `GITHUB_CLIENT_SECRET`,
  `GITHUB_CLIENT_ID`)와 측정 호스트 IP는 모두 `REPLACE_WITH_*` placeholder로
  마스킹 — 측정 시작 전 사용자가 production 값으로 치환
  - `sign-bench-tokens-cloud.mjs`는 `JWT_SECRET`/`DB_PASSWORD` 누락 시 명시적
  throw — default 값 사용 차단
  - 측정 결과(`results/`)와 토큰(`tokens.json`)은 `.gitignore` 추가 (호스트 의존
  큰 데이터)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 클라우드 환경에서 백엔드 동시 활성 연결 수 제한을 측정하기 위한 벤치마크 인프라 추가
  * AWS ECS Fargate에서 성능 테스트 실행 및 메트릭 수집을 위한 자동화 스크립트 추가
  * CloudWatch와 성능 메트릭 분석 도구 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->